### PR TITLE
Ensure Prometheus reinstalls correctly by checking Helm release

### DIFF
--- a/quickstart/llmd-infra-installer.sh
+++ b/quickstart/llmd-infra-installer.sh
@@ -254,7 +254,8 @@ install() {
       log_info "⚠️ ServiceMonitor CRD (monitoring.coreos.com) not found. Installing Prometheus stack."
       install_prometheus_grafana
     else
-      log_info "Skipping Prometheus installation as ServiceMonitor CRD already exists."
+      log_info "ServiceMonitor CRD found. Verifying Prometheus installation..."
+      install_prometheus_grafana
     fi
     log_info "Metrics collection enabled"
   fi


### PR DESCRIPTION
- Fixes Prometheus not being reinstalled during an uninstall/reinstall cycle.
- Always call install_prometheus_grafana function, even if the ServiceMonitor CRD is found. This function is idempotent and contains its own check to verify if the kube-prometheus-stack Helm release is already deployed and will safely skip the installation if it is.