### PR TITLE
remove the make command from prerequisits

### DIFF
--- a/quickstart/install-deps.sh
+++ b/quickstart/install-deps.sh
@@ -40,7 +40,7 @@ install_pkg() {
 }
 
 # Install base utilities
-for pkg in git jq make curl tar wget; do
+for pkg in git jq curl tar wget; do
   if ! command -v "$pkg" &> /dev/null; then
     install_pkg "$pkg"
   fi

--- a/quickstart/llmd-infra-installer.sh
+++ b/quickstart/llmd-infra-installer.sh
@@ -79,7 +79,7 @@ check_dependencies() {
     die "Detected yq is not mikefarah’s yq. Please install the required yq from https://github.com/mikefarah/yq?tab=readme-ov-file#install"
   fi
 
-  local required_cmds=(git yq jq helm helmfile kubectl kustomize make)
+  local required_cmds=(git yq jq helm helmfile kubectl kustomize)
   for cmd in "${required_cmds[@]}"; do
     check_cmd "$cmd"
   done


### PR DESCRIPTION
I read quickstart script and it seems like there is no line to use make commnad.
When I deploy llm-d-infra with quickstart script, I could deploy it in the environment where there isn't make command.