### PR TITLE
fixing examples with lessons learned from testing PD

### DIFF
--- a/quickstart/examples/pd-disaggregation/gaie-pd/values.yaml
+++ b/quickstart/examples/pd-disaggregation/gaie-pd/values.yaml
@@ -7,8 +7,8 @@ inferenceExtension:
     tag: 0.0.5
     pullPolicy: Always
   extProcPort: 9002
-  pluginConfigFile: "dp-config.yaml"
-  pluginCustomConfig:
+  pluginsConfigFile: "dp-config.yaml"
+  pluginsCustomConfig:
     dp-config.yaml: |
       apiVersion: inference.networking.x-k8s.io/v1alpha1
       kind: EndpointPickerConfig

--- a/quickstart/examples/pd-disaggregation/helmfile.yaml
+++ b/quickstart/examples/pd-disaggregation/helmfile.yaml
@@ -11,18 +11,6 @@ releases:
     labels:
       managedBy: llm-d-infra-installer
 
-  - name: ms-pd
-    namespace: llm-d
-    chart: llm-d-modelservice/llm-d-modelservice
-    version: 0.0.10
-    installed: true
-    needs:
-      - llm-d/infra-pd
-    values:
-      - ms-pd/values.yaml
-    labels:
-      managedBy: helmfile
-
   - name: gaie-pd
     namespace: llm-d
     chart: oci://us-central1-docker.pkg.dev/k8s-staging-images/gateway-api-inference-extension/charts/inferencepool
@@ -33,5 +21,18 @@ releases:
       - llm-d/infra-pd
     values:
       - gaie-pd/values.yaml
+    labels:
+      managedBy: helmfile
+
+  - name: ms-pd
+    namespace: llm-d
+    chart: llm-d-modelservice/llm-d-modelservice
+    version: 0.0.11
+    installed: true
+    needs:
+      - llm-d/infra-pd
+      - llm-d/gaie-pd
+    values:
+      - ms-pd/values.yaml
     labels:
       managedBy: helmfile

--- a/quickstart/examples/pd-disaggregation/ms-pd/values.yaml
+++ b/quickstart/examples/pd-disaggregation/ms-pd/values.yaml
@@ -14,7 +14,7 @@ routing:
       name: infra-pd-inference-gateway
 
   inferenceModel:
-    create: true
+    create: false
 
   inferencePool:
     create: false
@@ -64,8 +64,10 @@ decode:
     volumeMounts:
     - name: metrics-volume
       mountPath: /.config
-    - mountPath: /dev/shm
-      name: shm
+    - name: shm
+      mountPath: /dev/shm
+    - name: torch-compile-cache
+      mountPath: /.cache
   volumes:
   - name: metrics-volume
     emptyDir: {}
@@ -73,6 +75,8 @@ decode:
     emptyDir:
       medium: Memory
       sizeLimit: "16Gi"
+  - name: torch-compile-cache
+    emptyDir: {}
 
 prefill:
   create: true
@@ -112,8 +116,10 @@ prefill:
     volumeMounts:
     - name: metrics-volume
       mountPath: /.config
-    - mountPath: /dev/shm
-      name: shm
+    - name: shm
+      mountPath: /dev/shm
+    - name: torch-compile-cache
+      mountPath: /.cache
   volumes:
   - name: metrics-volume
     emptyDir: {}
@@ -121,3 +127,5 @@ prefill:
     emptyDir:
       medium: Memory
       sizeLimit: "16Gi"
+  - name: torch-compile-cache
+    emptyDir: {}

--- a/quickstart/examples/simple/helmfile.yaml
+++ b/quickstart/examples/simple/helmfile.yaml
@@ -11,18 +11,6 @@ releases:
     labels:
       managedBy: llm-d-infra-installer
 
-  - name: ms-simple
-    namespace: llm-d
-    chart: llm-d-modelservice/llm-d-modelservice
-    version: 0.0.10
-    installed: true
-    needs:
-      - llm-d/infra-simple
-    values:
-      - ms-simple/values.yaml
-    labels:
-      managedBy: helmfile
-
   - name: gaie-simple
     namespace: llm-d
     chart: oci://us-central1-docker.pkg.dev/k8s-staging-images/gateway-api-inference-extension/charts/inferencepool
@@ -33,5 +21,18 @@ releases:
       - llm-d/infra-simple
     values:
       - gaie-simple/values.yaml
+    labels:
+      managedBy: helmfile
+
+  - name: ms-simple
+    namespace: llm-d
+    chart: llm-d-modelservice/llm-d-modelservice
+    version: 0.0.11
+    installed: true
+    needs:
+      - llm-d/infra-simple
+      - llm-d/gaie-simple
+    values:
+      - ms-simple/values.yaml
     labels:
       managedBy: helmfile

--- a/quickstart/examples/simple/ms-simple/values.yaml
+++ b/quickstart/examples/simple/ms-simple/values.yaml
@@ -15,7 +15,7 @@ routing:
       name: infra-simple-inference-gateway
 
   inferenceModel:
-    create: true
+    create: false
 
   inferencePool:
     create: false
@@ -63,8 +63,12 @@ decode:
     volumeMounts:
     - name: metrics-volume
       mountPath: /.config
+    - name: torch-compile-cache
+      mountPath: /.cache
   volumes:
   - name: metrics-volume
+    emptyDir: {}
+  - name: torch-compile-cache
     emptyDir: {}
 
 # The prefill replica is disabled via 'create: false' since pd is not
@@ -107,6 +111,10 @@ prefill:
     volumeMounts:
     - name: metrics-volume
       mountPath: /.config
+    - name: torch-compile-cache
+      mountPath: /.cache
   volumes:
   - name: metrics-volume
+    emptyDir: {}
+  - name: torch-compile-cache
     emptyDir: {}


### PR DESCRIPTION
cc @robertgshaw2-redhat @nerdalert 

These were changes I saw from testing pd-simple on my fork:

1. Naming should be `pluginsConfigFile` and `pluginsCustomConfig` for the values in the GIE chart, not `pluginConfigFile` and `pluginCustomConfig` respectively
2. bumping modelservice chartversion
3. MS chart needs to be applied after GIE chart, otherwise its a 50/50 which resource gets made first (`inferencepool` or `httpRoute`) and thus the httpRoute sometimes fails to be programmed because it cannot find its inference model. Its fine if you kick it but it will fail until you do so
4. Mounting empty `/.cache` directory for torch compile backend that will cause crashes for some models that use the torch-compile backend if you dont have it