### PR TITLE
added lines for turn service LoadBalancer type

### DIFF
--- a/charts/llm-d-infra/templates/gateway-infrastructure/configmap.yaml
+++ b/charts/llm-d-infra/templates/gateway-infrastructure/configmap.yaml
@@ -34,5 +34,7 @@ data:
               - misc:error
               - --log_output_level
               - default:debug
-  service:
+  service: |
+    spec:
+      type: LoadBalancer
 {{- end}}


### PR DESCRIPTION
This PR is related to Issue #44.

When I deploy llm-d-infra with istio, the type of Service for GatewayAPI is ClusterIP.

```bash
NAME                                                      READY   STATUS    RESTARTS   AGE
pod/llm-d-infra-inference-gateway-istio-79b75bb5d-fvs95   1/1     Running   0          23h

NAME                                          TYPE        CLUSTER-IP     EXTERNAL-IP   PORT(S)            AGE
service/llm-d-infra-inference-gateway-istio   ClusterIP   10.233.20.78   <none>        15021/TCP,80/TCP   23h

NAME                                                              CLASS   ADDRESS                                                       PROGRAMMED   AGE
gateway.gateway.networking.k8s.io/llm-d-infra-inference-gateway   istio   llm-d-infra-inference-gateway-istio.llm-d.svc.cluster.local   True         23h
```

However I have to execute port-forward to access this Service.
Therefore I would like to change the type from ClusterIP to LoadBalancer.

```
NAME                                                      READY   STATUS    RESTARTS   AGE
pod/llm-d-infra-inference-gateway-istio-79b75bb5d-fvs95   1/1     Running   0          36h

NAME                                          TYPE           CLUSTER-IP     EXTERNAL-IP      PORT(S)                        AGE
service/llm-d-infra-inference-gateway-istio   LoadBalancer   10.233.20.78   192.168.92.193   15021:30568/TCP,80:31474/TCP   36h

NAME                                                              CLASS   ADDRESS          PROGRAMMED   AGE
gateway.gateway.networking.k8s.io/llm-d-infra-inference-gateway   istio   192.168.92.193   True         36h
```