### PR TITLE
Added option and removed unused options in quickstart script

### DIFF
--- a/quickstart/llmd-infra-installer.sh
+++ b/quickstart/llmd-infra-installer.sh
@@ -126,6 +126,7 @@ parse_args() {
       -k|--minikube)                   USE_MINIKUBE=true; shift ;;
       -g|--context)                    KUBERNETES_CONTEXT="$2"; shift 2 ;;
       -j|--gateway)                    GATEWAY_TYPE="$2"; shift 2 ;;
+      -s|--service-type)               SERVICE_TYPE="$2"; shift 2 ;;
       -r|--release)                    HELM_RELEASE_NAME="$2"; shift 2 ;;
       -h|--help)                       print_help; exit 0 ;;
       *)                               die "Unknown option: $1" ;;
@@ -307,7 +308,7 @@ install() {
     --set gateway.gatewayClassName="${GATEWAY_TYPE}" \
     --set gateway.gatewayParameters.proxyUID="${PROXY_UID}" \
     --set ingress.clusterRouterBase="${BASE_OCP_DOMAIN}" \
-    "${MODEL_OVERRIDE_ARGS[@]+"${MODEL_OVERRIDE_ARGS[@]}"}"
+    --set gateway.serviceType="${SERVICE_TYPE:-NodePort}"
   log_success "$HELM_RELEASE_NAME deployed"
 
   log_success "🎉 Installation complete."


### PR DESCRIPTION
# Summary

## 1. Added option to be able to change service type for GatewayAPI
It's re;ated to the PR ([enabling customization of isitio service type #34](https://github.com/llm-d-incubation/llm-d-infra/pull/34)).
After merged this PR, users can pass the service type for kgateway's gateway and istio's one in helm values.

Therefore when I use quickstart script, I think it's better that the user can choose service type as well.
And I added option for user to be able to change the service type.

## 2. Removed the unused options

The following options in helm installation commnad is unused.

```
"${MODEL_OVERRIDE_ARGS[@]+"${MODEL_OVERRIDE_ARGS[@]}"}"
```



# Test
## kgateway

### Default installation
```bash
$ ./llmd-infra-installer.sh -j kgateway -m
```

```bash
$ kubectl get pods,svc,gateway -n llm-d
NAME                                                 READY   STATUS    RESTARTS   AGE
pod/llm-d-infra-inference-gateway-69fd4dcfb9-hrf9r   1/1     Running   0          4s

NAME                                    TYPE       CLUSTER-IP      EXTERNAL-IP   PORT(S)        AGE
service/llm-d-infra-inference-gateway   NodePort   10.233.19.124   <none>        80:31644/TCP   4s

NAME                                                              CLASS      ADDRESS         PROGRAMMED   AGE
gateway.gateway.networking.k8s.io/llm-d-infra-inference-gateway   kgateway   10.233.19.124   True         4s
```

### Type LoadBalancer

```bash
$ ./llmd-infra-installer.sh -j kgateway -m -s LoadBalancer
```
```basg
$ kubectl get pods,svc,gateway -n llm-d
NAME                                                 READY   STATUS    RESTARTS   AGE
pod/llm-d-infra-inference-gateway-69fd4dcfb9-jhc5v   1/1     Running   0          3s

NAME                                    TYPE           CLUSTER-IP     EXTERNAL-IP     PORT(S)        AGE
service/llm-d-infra-inference-gateway   LoadBalancer   10.233.23.90   192.168.92.192  80:30475/TCP   3s

NAME                                                              CLASS      ADDRESS         PROGRAMMED   AGE
gateway.gateway.networking.k8s.io/llm-d-infra-inference-gateway   kgateway   192.168.92.192  True         3s
```

## Istio

### Default installation

```bash
$ ./llmd-infra-installer.sh -j istio -m
```

```bash
$ kubectl get pods,svc,gateway -n llm-d
NAME                                                       READY   STATUS    RESTARTS   AGE
pod/llm-d-infra-inference-gateway-istio-7c8566b849-8tqtl   0/1     Running   0          3s

NAME                                          TYPE       CLUSTER-IP      EXTERNAL-IP   PORT(S)                        AGE
service/llm-d-infra-inference-gateway-istio   NodePort   10.233.61.111   <none>        15021:30108/TCP,80:32468/TCP   3s

NAME                                                              CLASS   ADDRESS                                                       PROGRAMMED   AGE
gateway.gateway.networking.k8s.io/llm-d-infra-inference-gateway   istio   llm-d-infra-inference-gateway-istio.llm-d.svc.cluster.local   True         29s
```

### Type LoadBalancer

```bash
$ ./llmd-infra-installer.sh -j istio -m -s LoadBalancer
```

```bash
$ kubectl get pods,svc,gateway -n llm-d
NAME                                                       READY   STATUS    RESTARTS   AGE
pod/llm-d-infra-inference-gateway-istio-7c8566b849-gggxq   1/1     Running   0          23s

NAME                                          TYPE           CLUSTER-IP      EXTERNAL-IP     PORT(S)                        AGE
service/llm-d-infra-inference-gateway-istio   LoadBalancer   10.233.24.121   192.168.92.192  15021:30154/TCP,80:30943/TCP   23s

NAME                                                              CLASS   ADDRESS         PROGRAMMED   AGE
gateway.gateway.networking.k8s.io/llm-d-infra-inference-gateway   istio   192.168.92.192  True         44s
```