### PR TITLE
Add example liveness, startup and readiness probes to the sim example

### DIFF
--- a/quickstart/examples/sim/ms-sim/values.yaml
+++ b/quickstart/examples/sim/ms-sim/values.yaml
@@ -42,6 +42,28 @@ decode:
     volumeMounts:
     - name: metrics-volume
       mountPath: /.config
+    startupProbe:
+      httpGet:
+        path: /health
+        port: 8200
+      initialDelaySeconds: 15
+      periodSeconds: 30
+      timeoutSeconds: 5
+      failureThreshold: 60
+    livenessProbe:
+      httpGet:
+        path: /health
+        port: 8200
+      periodSeconds: 10
+      timeoutSeconds: 5
+      failureThreshold: 3
+    readinessProbe:
+      httpGet:
+        path: /health
+        port: 8200
+      periodSeconds: 5
+      timeoutSeconds: 2
+      failureThreshold: 3
   volumes:
   - name: metrics-volume
     emptyDir: {}
@@ -60,6 +82,27 @@ prefill:
     volumeMounts:
     - name: metrics-volume
       mountPath: /.config
+    startupProbe:
+      httpGet:
+        path: /health
+        port: 8000
+      initialDelaySeconds: 15
+      periodSeconds: 30
+      timeoutSeconds: 5
+      failureThreshold: 60
+    livenessProbe:
+      httpGet:
+        path: /health
+        port: 8000
+      periodSeconds: 10
+      timeoutSeconds: 5
+      failureThreshold: 3
+    readinessProbe:
+      httpGet:
+        path: /health
+        port: 8000
+      periodSeconds: 5
+      timeoutSeconds: 2
   volumes:
   - name: metrics-volume
     emptyDir: {}


### PR DESCRIPTION
Wanted to show an example of probes for p and d pods and figured sim is a good place to start, since there aren't very many options in the values file compared to the other paths, that will create clutter.