### PR TITLE
bump GIE charts to release image

### DIFF
--- a/quickstart/examples/pd-disaggregation/helmfile.yaml
+++ b/quickstart/examples/pd-disaggregation/helmfile.yaml
@@ -14,7 +14,7 @@ releases:
   - name: gaie-pd
     namespace: llm-d
     chart: oci://us-central1-docker.pkg.dev/k8s-staging-images/gateway-api-inference-extension/charts/inferencepool
-    version: v0.5.1-rc.1
+    version: v0.5.1
     installed: true
     needs:
       - llm-d/infra-pd


### PR DESCRIPTION
cc @robertgshaw2-redhat, `inference-scheduler` is already fixed