### PR TITLE
Cleanup inference scheduling example v2

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -7,3 +7,7 @@
 /quickstart/examples/precise-prefix-cache-aware/ @vMaroon @ahg-g
 /quickstart/examples/sim/ @shmuelk
 /quickstart/examples/wide-ep-lws/ @njhill @wseaton
+
+# GKE specific example files
+**/gke.helmfile.yaml  @liu-cong @smarterclayton
+**/gke.md             @liu-cong @smarterclayton

--- a/quickstart/examples/inference-scheduling/README.md
+++ b/quickstart/examples/inference-scheduling/README.md
@@ -19,18 +19,17 @@ cd quickstart
 export HF_TOKEN=${HFTOKEN}
 ./llmd-infra-installer.sh --namespace llm-d-inference-scheduling -r infra-inference-scheduling --gateway kgateway --disable-metrics-collection
 ```
-    - It should be noted release name `infra-inference-scheduling` is important here, because it matches up with pre-built values files used in this example.
+
+**_NOTE:_** The release name `infra-inference-scheduling` is important here, because it matches up with pre-built values files used in this example.
 
 3. Use the helmfile to apply the modelservice and GIE charts on top of it.
 
 ```bash
 cd examples/inference-scheduling
-helmfile --selector managedBy=helmfile apply helmfile.yaml --skip-diff-on-install
+helmfile --selector managedBy=helmfile apply -f helmfile.yaml --skip-diff-on-install
 ```
 
----
-
-> Note: if you are deploying Istio as the gateway, e.g. `--gateway istio`, then you will need to apply a `DestinationRule` described in [Temporary Istio Workaround](../../istio-workaround.md).
+**_NOTE:_** If you are deploying Istio as the gateway, e.g. `--gateway istio`, then you will need to apply a `DestinationRule` described in [Temporary Istio Workaround](../../istio-workaround.md).
 
 ## Verify the Installation
 

--- a/quickstart/examples/inference-scheduling/gke.helmfile.yaml
+++ b/quickstart/examples/inference-scheduling/gke.helmfile.yaml
@@ -18,6 +18,9 @@ releases:
       - infra-inference-scheduling
     values:
       - gaie-inference-scheduling/values.yaml
+    setString:
+      - name: provider.name
+        value: gke
     labels:
       managedBy: helmfile
 

--- a/quickstart/examples/inference-scheduling/gke.helmfile.yaml
+++ b/quickstart/examples/inference-scheduling/gke.helmfile.yaml
@@ -4,7 +4,6 @@ repositories:
 
 releases:
   - name: infra-inference-scheduling
-    namespace: llm-d-inference-scheduling
     chart: oci://ghcr.io/llm-d-incubation/llm-d-infra/llm-d-infra
     version: v1.1.0
     installed: true
@@ -12,25 +11,23 @@ releases:
       managedBy: llm-d-infra-installer
 
   - name: gaie-inference-scheduling
-    namespace: llm-d-inference-scheduling
     chart: oci://registry.k8s.io/gateway-api-inference-extension/charts/inferencepool
     version: v0.5.1
     installed: true
     needs:
-      - llm-d-inference-scheduling/infra-inference-scheduling
+      - infra-inference-scheduling
     values:
       - gaie-inference-scheduling/values.yaml
     labels:
       managedBy: helmfile
 
   - name: ms-inference-scheduling
-    namespace: llm-d-inference-scheduling
     chart: llm-d-modelservice/llm-d-modelservice
     version: v0.2.0
     installed: true
     needs:
-      - llm-d-inference-scheduling/infra-inference-scheduling
-      - llm-d-inference-scheduling/gaie-inference-scheduling
+      - infra-inference-scheduling
+      - gaie-inference-scheduling
     values:
       - ms-inference-scheduling/values.yaml
     labels:

--- a/quickstart/examples/inference-scheduling/gke.helmfile.yaml
+++ b/quickstart/examples/inference-scheduling/gke.helmfile.yaml
@@ -4,7 +4,7 @@ repositories:
 
 releases:
   - name: infra-inference-scheduling
-    chart: oci://ghcr.io/llm-d-incubation/llm-d-infra/llm-d-infra
+    chart: https://llm-d-incubation.github.io/llm-d-infra/
     version: v1.1.0
     installed: true
     labels:

--- a/quickstart/examples/inference-scheduling/gke.md
+++ b/quickstart/examples/inference-scheduling/gke.md
@@ -16,16 +16,17 @@ cd quickstart
 export HF_TOKEN=$(YOUR_TOKEN)
 ./llmd-infra-installer.sh --namespace ${NAMESPACE} -r infra-inference-scheduling --gateway ${GATEWAY} --disable-metrics-collection
 ```
-    - It should be noted release name `infra-inference-scheduling` is important here, because it matches up with pre-built values files used in this example.
+
+**_NOTE:_** It should be noted release name `infra-inference-scheduling` is important here, because it matches up with pre-built values files used in this example.
 
 3. Use the helmfile to apply the modelservice and GIE charts on top of it.
 
-  ```bash
-  cd examples/inference-scheduling
-  helmfile --namespace ${NAMESPACE} --selector managedBy=helmfile \
-  --set provider.name=gke \
-  apply gke.helmfile.yaml --skip-diff-on-install
-  ```
+```bash
+cd examples/inference-scheduling
+helmfile --namespace ${NAMESPACE} --selector managedBy=helmfile \
+--set provider.name=gke \
+apply -f gke.helmfile.yaml --skip-diff-on-install
+```
 
 ## Verify the Installation
 
@@ -41,12 +42,11 @@ ms-inference-scheduling   	llm-d-inference-scheduling	1       	2025-07-24 10:44:
 
 1. Get the gateway endpoint:
 
-    ```bash
-    GATEWAY_NAME=infra-inference-scheduling-inference-gateway
-    IP=$(kubectl get gateway/${GATEWAY_NAME} -n ${NAMESPACE} -o jsonpath='{.status.addresses[0].value}')
-
-    PORT=80
-    ```
+```bash
+GATEWAY_NAME=infra-inference-scheduling-inference-gateway
+IP=$(kubectl get gateway/${GATEWAY_NAME} -n ${NAMESPACE} -o jsonpath='{.status.addresses[0].value}')
+PORT=80
+```
 
 1. Try curling the `/v1/models` endpoint:
 
@@ -128,5 +128,5 @@ To remove the deployment:
 helmfile --selector managedBy=helmfile destroy --namespace ${NAMESPACE}
 
 # Remove the infrastructure
-helm uninstall infra-inference-scheduling -n ${NAMESPACE}
+helm uninstall infra-inference-scheduling --namespace ${NAMESPACE}
 ```

--- a/quickstart/examples/inference-scheduling/gke.md
+++ b/quickstart/examples/inference-scheduling/gke.md
@@ -23,9 +23,10 @@ export HF_TOKEN=$(YOUR_TOKEN)
 
 ```bash
 cd examples/inference-scheduling
-helmfile --namespace ${NAMESPACE} --selector managedBy=helmfile \
---set provider.name=gke \
-apply -f gke.helmfile.yaml --skip-diff-on-install
+helmfile apply \
+  --namespace ${NAMESPACE} \
+  --selector managedBy=helmfile \
+  apply -f gke.helmfile.yaml --skip-diff-on-install
 ```
 
 ## Verify the Installation

--- a/quickstart/examples/inference-scheduling/helmfile.yaml
+++ b/quickstart/examples/inference-scheduling/helmfile.yaml
@@ -5,7 +5,7 @@ repositories:
 releases:
   - name: infra-inference-scheduling
     namespace: llm-d-inference-scheduling
-    chart: oci://ghcr.io/llm-d-incubation/llm-d-infra/llm-d-infra
+    chart: https://llm-d-incubation.github.io/llm-d-infra/
     version: v1.1.0
     installed: true
     labels:

--- a/quickstart/examples/pd-disaggregation/helmfile.yaml
+++ b/quickstart/examples/pd-disaggregation/helmfile.yaml
@@ -5,7 +5,7 @@ repositories:
 releases:
   - name: infra-pd
     namespace: llm-d-pd
-    chart: oci://ghcr.io/llm-d-incubation/llm-d-infra/llm-d-infra
+    chart: https://llm-d-incubation.github.io/llm-d-infra/
     version: v1.1.0
     installed: true
     values:

--- a/quickstart/examples/precise-prefix-cache-aware/helmfile.yaml
+++ b/quickstart/examples/precise-prefix-cache-aware/helmfile.yaml
@@ -5,7 +5,7 @@ repositories:
 releases:
   - name: infra-kv-events
     namespace: llm-d-precise
-    chart: oci://ghcr.io/llm-d-incubation/llm-d-infra/llm-d-infra
+    chart: https://llm-d-incubation.github.io/llm-d-infra/
     version: v1.1.0
     installed: true
     labels:

--- a/quickstart/examples/sim/helmfile.yaml
+++ b/quickstart/examples/sim/helmfile.yaml
@@ -5,7 +5,7 @@ repositories:
 releases:
   - name: infra-sim
     namespace: llm-d-sim
-    chart: oci://ghcr.io/llm-d-incubation/llm-d-infra/llm-d-infra
+    chart: https://llm-d-incubation.github.io/llm-d-infra/
     version: v1.1.0
     installed: true
     labels:

--- a/quickstart/examples/wide-ep-lws/helmfile.yaml
+++ b/quickstart/examples/wide-ep-lws/helmfile.yaml
@@ -5,7 +5,7 @@ repositories:
 releases:
   - name: infra-wide-ep
     namespace: llm-d-wide-ep
-    chart: oci://ghcr.io/llm-d-incubation/llm-d-infra/llm-d-infra
+    chart: https://llm-d-incubation.github.io/llm-d-infra/
     version: v1.1.0
     installed: true
     values:


### PR DESCRIPTION
cc @liu-cong 

Helmfile usage for apply states:

```
helmfile apply --help
Apply all resources from state file only when there are changes

Usage:
  helmfile apply [flags]

```
Rather than taking the file in question as a directive it defaults to `helmfile.yaml`, `helmfile.yaml.gotmpl` or `helmfile.d` in that order.

Additionally the change that makes the namespace variable will not work with the current setup because the `helmfile` explicitly states what release will be installed in what namespace ([example](https://github.com/llm-d-incubation/llm-d-infra/blob/main/quickstart/examples/inference-scheduling/helmfile.yaml#L15)). I have removed those sections from the GKE `helmfile` and docs - so this should fix your current setup.

Feel free to edit, take or drop anything for the GKE stuff you own that piece of every example with the change in the code-owners file