### PR TITLE
Update README.md to correct link for OpenShift and Grafana section

### DIFF
--- a/quickstart/README.md
+++ b/quickstart/README.md
@@ -228,7 +228,7 @@ prometheus-community [kube-prometheus-stack helm charts](https://github.com/prom
 
 #### Accessing the Metrics UIs
 
-If running on OpenShift, skip to [OpenShift and Grafana](#openshift-and-grafana).
+If running on OpenShift, skip to [OpenShift and Grafana](./docs/infra-providers/openshift/README-openshift.md#openshift-and-grafana).
 
 #### Port Forwarding
 


### PR DESCRIPTION
In the migration from deployer to infra it looks like we lost the content for this anchor, so i've linked to the correct(?) file/section. 
