### PR TITLE
[inference-scheduling] Modied README for the user who create infra with quickstart README

### DIFF
--- a/quickstart/examples/inference-scheduling/README.md
+++ b/quickstart/examples/inference-scheduling/README.md
@@ -23,6 +23,13 @@ export HF_TOKEN=${HFTOKEN}
 
 **_NOTE:_** The release name `infra-inference-scheduling` is important here, because it matches up with pre-built values files used in this example.
 
+If you have already deployed llm-d-infra according to [README.md](../../README.md) or [README-step-by-step.md](../../README-step-by-step.md), you have to execute the following commnad to overwrite the release name and namespace before applying helmfile in the next step.
+
+```
+sed -i 's/llm-d-inference-scheduling/llm-d/g' helmfile.yaml
+sed -i 's/infra-inference-scheduling/llm-d-infra/g' helmfile.yaml
+```
+
 3. Use the helmfile to apply the modelservice and GIE charts on top of it.
 
 ```bash


### PR DESCRIPTION
Added the few discriptions for the users who create llm-d-infra with quickstart README.

They are create llm-d nfrastructure with release name "llm-d-infra" in llm-d namespace.

Therefore this discription is important for them.

With this description, the result is like below.

```
# helm ls -n llm-d
NAME                            NAMESPACE       REVISION        UPDATED                                 STATUS          CHART                           APP VERSION
gaie-inference-scheduling       llm-d           1               2025-08-01 04:00:27.366772101 +0900 JST deployed        inferencepool-v0.5.1            v0.5.1
llm-d-infra                     llm-d           1               2025-07-17 17:29:49.317253193 +0900 JST deployed        llm-d-infra-1.0.5               0.1
ms-inference-scheduling         llm-d           1               2025-08-01 04:00:30.002792389 +0900 JST deployed        llm-d-modelservice-0.2.0        v0.2.0
```