### PR TITLE
Bumps kgateway Version

### DIFF
--- a/chart-dependencies/kgateway/install.sh
+++ b/chart-dependencies/kgateway/install.sh
@@ -2,17 +2,21 @@
 
 MODE=${1:-apply}
 
+# The version of Kgateway to install. Use "v2.1.0-main" for the latest
+# build from the Kgateway main branch.
+KGTW_VERSION=${KGTW_VERSION:-"v2.0.4"}
+
 if [[ "$MODE" == "apply" ]]; then
   helm upgrade -i \
     --namespace kgateway-system \
     --create-namespace \
-    --version v2.0.3 \
+    --version "${KGTW_VERSION}" \
     kgateway-crds oci://cr.kgateway.dev/kgateway-dev/charts/kgateway-crds
 
   helm upgrade -i \
     --namespace kgateway-system \
     --create-namespace \
-    --version v2.0.3 \
+    --version "${KGTW_VERSION}" \
     --set inferenceExtension.enabled=true \
     --set securityContext.allowPrivilegeEscalation=false \
     --set securityContext.capabilities.drop={ALL} \
@@ -22,5 +26,5 @@ if [[ "$MODE" == "apply" ]]; then
 else
   helm uninstall kgateway --ignore-not-found  --namespace kgateway-system || true
   helm uninstall kgateway-crds --ignore-not-found --namespace kgateway-system || true
-  helm template kgateway-crds oci://cr.kgateway.dev/kgateway-dev/charts/kgateway-crds --version v2.0.3 | kubectl delete -f - --ignore-not-found
+  helm template kgateway-crds oci://cr.kgateway.dev/kgateway-dev/charts/kgateway-crds --version "${KGTW_VERSION}" | kubectl delete -f - --ignore-not-found
 fi

--- a/quickstart/README-step-by-step.md
+++ b/quickstart/README-step-by-step.md
@@ -106,13 +106,14 @@ istio-remote   istio.io/unmanaged-gateway    True       39s
 
 #### Installing kgateway
 
-Apply kgateway CRD.
+Apply the kgateway CRDs.
 
 ```bash
+KGTW_VERSION="v2.0.4"
 helm upgrade -i \
   --namespace kgateway-system \
   --create-namespace \
-  --version v2.0.3 \
+  --version "${KGTW_VERSION}" \
   kgateway-crds oci://cr.kgateway.dev/kgateway-dev/charts/kgateway-crds
 ```
 
@@ -122,13 +123,19 @@ After that, deploy kgateway.
 helm upgrade -i \
   --namespace kgateway-system \
   --create-namespace \
-  --version v2.0.3 \
+  --version "${KGTW_VERSION}" \
   --set inferenceExtension.enabled=true \
   --set securityContext.allowPrivilegeEscalation=false \
   --set securityContext.capabilities.drop={ALL} \
   --set podSecurityContext.seccompProfile.type=RuntimeDefault \
   --set podSecurityContext.runAsNonRoot=true \
   kgateway oci://cr.kgateway.dev/kgateway-dev/charts/kgateway
+```
+
+Wait for the kgateway rollout to complete:
+
+```bash
+kubectl rollout status deploy/kgateway -n kgateway-system
 ```
 
 The resources are created as follows:
@@ -163,6 +170,7 @@ Create a namespace to deploy llm-d-infra.
 - [inference-scheduling](./examples/inference-scheduling): llm-d-inference-scheduling
 - [pd-disaggregation](./examples/pd-disaggregation): llm-d-pd
 - [precise-prefix-cache-aware](./examples/precise-prefix-cache-aware): llm-d-wide-ep
+- [llm-d-simulator](./examples/sim): llm-d-sim
 
 ```bash
 export NAMESPACE="llm-d"
@@ -216,9 +224,9 @@ helm upgrade -i llm-d-infra . --namespace "${NAMESPACE}" \
   --set gateway.gatewayParameters.proxyUID=0
 ```
 
-Service is create as NodePort type.
+Service is created as LoadBalancer type.
 
-If you want to change Service type, then please add the `serviceType` option like `--set gateway.serviceType=LoadBalancer`.
+If you want to change Service type, then please add the `serviceType` option like `--set gateway.serviceType=NodePort`.
 
 ## Validation
 

--- a/quickstart/examples/sim/README.md
+++ b/quickstart/examples/sim/README.md
@@ -13,7 +13,7 @@ As documented in the [GIE values file](./gaie-sim/values.yaml#L4-L13), either th
 > To adjust the simulation settings or any other modelservice values, simply change the values.yaml file in [ms-llm-d-sim/values.yaml](ms-llm-d-sim/values.yaml)
 
 1. Install the dependencies; see [install-deps.sh](../../install-deps.sh)
-2. Use the quickstart to deploy Gateway CRDS + Gateway provider + Infra chart:
+2. Use the quickstart to deploy Gateway CRDs + Gateway provider + Infra chart:
 
 ```bash
 # From the repo root


### PR DESCRIPTION
- Bumps the kgateway version to v2.0.4 (Gateway API Inference Extension [conformant](https://github.com/kubernetes-sigs/gateway-api-inference-extension/tree/main/conformance/reports/v0.5.1/gateway/kgateway)).
- Minor docs fixes.