### PR TITLE
Enable any namespace per quickstart

### DIFF
--- a/quickstart/examples/inference-scheduling/README.md
+++ b/quickstart/examples/inference-scheduling/README.md
@@ -1,5 +1,9 @@
 # Well-lit Path: Intelligent Inference Scheduling
 
+## requirements
+
+2 nvidia GPUs of any kind
+
 ## Overview
 
 This example deploys the recommended out of the box [scheduling configuration](https://github.com/llm-d/llm-d-inference-scheduler/blob/main/docs/architecture.md) for most vLLM deployments, reducing tail latency and increasing throughput through load-aware and prefix-cache aware balancing. This can be run on a single GPU that can load [Qwen/Qwen3-0.6B](https://huggingface.co/Qwen/Qwen3-0.6B).
@@ -18,7 +22,8 @@ This profile defaults to the approximate prefix cache aware scorer, which only o
     # From the repo root
     cd quickstart
     export HF_TOKEN=${HFTOKEN}
-    ./llmd-infra-installer.sh --namespace llm-d-inference-scheduling -r infra-inference-scheduling --gateway kgateway --disable-metrics-collection
+    export NAMESPACE=${NAMESPACE:-llm-d-inference-scheduling}
+    ./llmd-infra-installer.sh --namespace ${NAMESPACE} -r infra-inference-scheduling --gateway kgateway --disable-metrics-collection
     ```
 
     **_NOTE:_** The release name `infra-inference-scheduling` is important here, because it matches up with pre-built values files used in this example.
@@ -37,7 +42,7 @@ This profile defaults to the approximate prefix cache aware scorer, which only o
 1. Firstly, you should be able to list all helm releases to view the 3 charts got installed into the `llm-d-inference-scheduling` namespace:
 
     ```bash
-    helm list -n llm-d-inference-scheduling
+    helm list -n ${NAMESPACE}
     NAME                          NAMESPACE                     REVISION    UPDATED                                 STATUS      CHART                        APP VERSION
     gaie-inference-scheduling     llm-d-inference-scheduling    1           2025-07-24 10:44:30.543527 -0700 PDT    deployed    inferencepool-v0.5.1         v0.5.1
     infra-inference-scheduling    llm-d-inference-scheduling    1           2025-07-24 10:41:49.452841 -0700 PDT    deployed    llm-d-infra-v1.1.1        v0.2.0
@@ -47,7 +52,7 @@ This profile defaults to the approximate prefix cache aware scorer, which only o
 1. Find the gateway service:
 
     ```bash
-    kubectl get services -n llm-d-inference-scheduling
+    kubectl get services -n ${NAMESPACE}
     NAME                                           TYPE        CLUSTER-IP    EXTERNAL-IP   PORT(S)             AGE
     gaie-inference-scheduling-epp                  ClusterIP   10.16.0.249   <none>        9002/TCP,9090/TCP   96s
     infra-inference-scheduling-inference-gateway   NodePort    10.16.3.58    <none>        80:33377/TCP        4m19s
@@ -55,10 +60,10 @@ This profile defaults to the approximate prefix cache aware scorer, which only o
 
     In this case we have found that our gateway service is called `infra-inference-scheduling-inference-gateway`.
 
-1. `port-forward` the service so we can curl it:
+1. `port-forward` the service to we can curl it:
 
     ```bash
-    kubectl port-forward -n llm-d-inference-scheduling service/infra-inference-scheduling-inference-gateway 8000:80
+    kubectl port-forward -n ${NAMESPACE} service/infra-inference-scheduling-inference-gateway 8000:80
     ```
 
 1. Try curling the `/v1/models` endpoint:
@@ -143,7 +148,7 @@ To remove the deployment:
 helmfile --selector managedBy=helmfile destroy -f helmfile.yaml
 
 # Remove the infrastructure
-helm uninstall infra-inference-scheduling -n llm-d-inference-scheduling
+helm uninstall infra-inference-scheduling -n ${NAMESPACE}
 ```
 
 ## Customization

--- a/quickstart/examples/inference-scheduling/helmfile.yaml
+++ b/quickstart/examples/inference-scheduling/helmfile.yaml
@@ -4,7 +4,6 @@ repositories:
 
 releases:
   - name: infra-inference-scheduling
-    namespace: llm-d-inference-scheduling
     chart: https://llm-d-incubation.github.io/llm-d-infra/
     version: v1.1.1
     installed: true
@@ -12,25 +11,23 @@ releases:
       managedBy: llm-d-infra-installer
 
   - name: gaie-inference-scheduling
-    namespace: llm-d-inference-scheduling
     chart: oci://registry.k8s.io/gateway-api-inference-extension/charts/inferencepool
     version: v0.5.1
     installed: true
     needs:
-      - llm-d-inference-scheduling/infra-inference-scheduling
+      - infra-inference-scheduling
     values:
       - gaie-inference-scheduling/values.yaml
     labels:
       managedBy: helmfile
 
   - name: ms-inference-scheduling
-    namespace: llm-d-inference-scheduling
     chart: llm-d-modelservice/llm-d-modelservice
     version: v0.2.0
     installed: true
     needs:
-      - llm-d-inference-scheduling/infra-inference-scheduling
-      - llm-d-inference-scheduling/gaie-inference-scheduling
+      - infra-inference-scheduling
+      - gaie-inference-scheduling
     values:
       - ms-inference-scheduling/values.yaml
     labels:

--- a/quickstart/examples/pd-disaggregation/README.md
+++ b/quickstart/examples/pd-disaggregation/README.md
@@ -44,7 +44,8 @@ As a result, as you tune your P/D deployments, we suggest focusing on the follow
    # ran from root of repo
    cd quickstart
    export HF_TOKEN=${HFTOKEN}
-   ./llmd-infra-installer.sh --namespace llm-d-pd -r infra-pd -f examples/pd-disaggregation/infra-pd/values.yaml --disable-metrics-collection
+   export NAMESPACE=${NAMESPACE:-llm-d-pd}
+   ./llmd-infra-installer.sh --namespace ${NAMESPACE} -r infra-pd -f examples/pd-disaggregation/infra-pd/values.yaml --disable-metrics-collection
    ```
 
    **_NOTE:_** The release name `infra-pd` is important here, because it matches up with pre-built values files used in this example.
@@ -58,10 +59,10 @@ As a result, as you tune your P/D deployments, we suggest focusing on the follow
 
 ## Verifying the installation
 
-1. First, let's check that all three charts were deployed successfully to our `llm-d-pd` namespace:
+1. First, let's check that all three charts were deployed successfully to our chosen namespace:
 
 ```bash
-$ helm list -n llm-d-pd
+$ helm list -n ${NAMESPACE}
 NAME        NAMESPACE    REVISION    UPDATED                                 STATUS      CHART                       APP VERSION
 gaie-pd     llm-d-pd     1           2025-07-25 11:27:47.419598 -0700 PDT    deployed    inferencepool-v0.5.1        v0.5.1
 infra-pd    llm-d-pd     1           2025-07-25 11:27:18.453254 -0700 PDT    deployed    llm-d-infra-v1.1.1          v0.2.0
@@ -71,7 +72,7 @@ ms-pd       llm-d-pd     1           2025-07-25 11:27:53.138175 -0700 PDT    dep
 1. Next, let's check the pod health of our 4 prefill replicas and 1 decode replica:
 
 ```bash
-$ kubectl get pods -n llm-d-pd
+$ kubectl get pods -n ${NAMESPACE}
 NAME                                                READY   STATUS    RESTARTS   AGE
 gaie-pd-epp-69888bdd8d-6pnbk                        1/1     Running   0          54s
 infra-pd-inference-gateway-istio-776797b79f-6clvr   1/1     Running   0          2m9s
@@ -85,7 +86,7 @@ ms-pd-llm-d-modelservice-prefill-549598dd6c-pbjzx   1/1     Running   0         
 1. Find the gateway service:
 
 ```bash
-$ kubectl get services -n llm-d-pd
+$ kubectl get services -n ${NAMESPACE}
 NAME                               TYPE        CLUSTER-IP    EXTERNAL-IP   PORT(S)                        AGE
 gaie-pd-epp                        ClusterIP   10.16.0.161   <none>        9002/TCP,9090/TCP              6m6s
 gaie-pd-ip-bb618139                ClusterIP   None          <none>        54321/TCP                      6m1s
@@ -97,7 +98,7 @@ In this case we have found that our gateway service is called `infra-pd-inferenc
 1. `port-forward` the service so we can curl it:
 
 ```bash
-kubectl port-forward -n llm-d-pd service/infra-pd-inference-gateway-istio 8000:80
+kubectl port-forward -n ${NAMESPACE} service/infra-pd-inference-gateway-istio 8000:80
 ```
 
 1. Try curling the `/v1/models` endpoint:
@@ -184,7 +185,7 @@ To remove the deployment:
 helmfile --selector managedBy=helmfile destroy -f helmfile.yaml
 
 # Remove the infrastructure
-helm uninstall infra-pd -n llm-d-pd
+helm uninstall infra-pd -n ${NAMESPACE}
 ```
 
 ## Customization

--- a/quickstart/examples/pd-disaggregation/gke.helmfile.yaml
+++ b/quickstart/examples/pd-disaggregation/gke.helmfile.yaml
@@ -4,7 +4,6 @@ repositories:
 
 releases:
   - name: infra-pd
-    namespace: llm-d-pd
     chart: oci://ghcr.io/llm-d-incubation/llm-d-infra/llm-d-infra
     version: v1.1.0
     installed: true
@@ -14,25 +13,23 @@ releases:
       managedBy: llm-d-infra-installer
 
   - name: gaie-pd
-    namespace: llm-d-pd
     chart: oci://registry.k8s.io/gateway-api-inference-extension/charts/inferencepool
     version: v0.5.1
     installed: true
     needs:
-      - llm-d-pd/infra-pd
+      - infra-pd
     values:
       - gaie-pd/values.yaml
     labels:
       managedBy: helmfile
 
   - name: ms-pd
-    namespace: llm-d-pd
     chart: llm-d-modelservice/llm-d-modelservice
     version: v0.2.0
     installed: true
     needs:
-      - llm-d-pd/infra-pd
-      - llm-d-pd/gaie-pd
+      - infra-pd
+      - gaie-pd
     values:
       - ms-pd/values.yaml
     labels:
@@ -45,7 +42,7 @@ releases:
           - |
             echo "Patching HTTPRoute to trigger reconciliation..."
             kubectl patch httproute ms-pd-llm-d-modelservice \
-              -n llm-d-pd \
+              -n ${NAMESPACE} \
               -p '{"metadata":{"labels":{"inferencepool":"gaie-pd"}}}' \
               --type=merge
       # NOTE: This is a temporary workaround.

--- a/quickstart/examples/pd-disaggregation/gke.md
+++ b/quickstart/examples/pd-disaggregation/gke.md
@@ -41,7 +41,7 @@
 
 ## Verifying the installation
 
-1. First lets check that all three charts were deployed successfully to our `llm-d-pd` namespace:
+1. First lets check that all three charts were deployed successfully to our chosen namespace:
 
     ```bash
     $ helm list -n ${NAMESPACE}

--- a/quickstart/examples/pd-disaggregation/helmfile.yaml
+++ b/quickstart/examples/pd-disaggregation/helmfile.yaml
@@ -4,7 +4,6 @@ repositories:
 
 releases:
   - name: infra-pd
-    namespace: llm-d-pd
     chart: https://llm-d-incubation.github.io/llm-d-infra/
     version: v1.1.1
     installed: true
@@ -14,25 +13,23 @@ releases:
       managedBy: llm-d-infra-installer
 
   - name: gaie-pd
-    namespace: llm-d-pd
     chart: oci://registry.k8s.io/gateway-api-inference-extension/charts/inferencepool
     version: v0.5.1
     installed: true
     needs:
-      - llm-d-pd/infra-pd
+      - infra-pd
     values:
       - gaie-pd/values.yaml
     labels:
       managedBy: helmfile
 
   - name: ms-pd
-    namespace: llm-d-pd
     chart: llm-d-modelservice/llm-d-modelservice
     version: v0.2.0
     installed: true
     needs:
-      - llm-d-pd/infra-pd
-      - llm-d-pd/gaie-pd
+      - infra-pd
+      - gaie-pd
     values:
       - ms-pd/values.yaml
     labels:
@@ -45,6 +42,6 @@ releases:
           - |
             echo "Patching HTTPRoute to trigger reconciliation..."
             kubectl patch httproute ms-pd-llm-d-modelservice \
-              -n llm-d-pd \
+              -n ${NAMESPACE} \
               -p '{"metadata":{"labels":{"inferencepool":"gaie-pd"}}}' \
               --type=merge

--- a/quickstart/examples/pd-disaggregation/helmfile.yaml
+++ b/quickstart/examples/pd-disaggregation/helmfile.yaml
@@ -34,14 +34,3 @@ releases:
       - ms-pd/values.yaml
     labels:
       managedBy: helmfile
-    hooks:
-      - events: [ "postsync" ]
-        command: bash
-        args:
-          - -c
-          - |
-            echo "Patching HTTPRoute to trigger reconciliation..."
-            kubectl patch httproute ms-pd-llm-d-modelservice \
-              -n ${NAMESPACE} \
-              -p '{"metadata":{"labels":{"inferencepool":"gaie-pd"}}}' \
-              --type=merge

--- a/quickstart/examples/pd-disaggregation/infra-pd/values.yaml
+++ b/quickstart/examples/pd-disaggregation/infra-pd/values.yaml
@@ -11,7 +11,7 @@ gateway:
         memory: 1Gi
   destinationRule:
     enabled: true
-    host: gaie-pd-epp.llm-d-pd.svc.cluster.local
+    host: gaie-pd-epp.svc.cluster.local # THIS NEEDS TO BE ADDRESSED UPSTREAM GIE AND MIGRATED THERE
     trafficPolicy:
       connectionPool:
         http:

--- a/quickstart/examples/precise-prefix-cache-aware/README.md
+++ b/quickstart/examples/precise-prefix-cache-aware/README.md
@@ -17,7 +17,8 @@ This is a simple quickstart demonstrating how to configure the inference schedul
 # From the repo root
 cd quickstart
 export HF_TOKEN=${HFTOKEN}
-./llmd-infra-installer.sh --namespace llm-d-precise -r infra-kv-events --gateway kgateway --disable-metrics-collection
+export NAMESPACE=${NAMESPACE:-llm-d-precise}
+./llmd-infra-installer.sh --namespace ${NAMESPACE} -r infra-kv-events --gateway kgateway --disable-metrics-collection
 ```
 
 **_NOTE:_** The release name `infra-kv-events` is important here, because it matches up with pre-built values files used in this example.
@@ -31,10 +32,10 @@ helmfile --selector managedBy=helmfile apply -f helmfile.yaml --skip-diff-on-ins
 
 ## Verify the Installation
 
-1. Firstly, you should be able to list all helm releases in the `llm-d-precise` ns to view all 3 charts that should be installed:
+1. Firstly, you should be able to list all helm releases in the chosen ns to view all 3 charts that should be installed:
 
 ```bash
-$ helm list -n llm-d-precise --all --debug
+$ helm list -n ${NAMESPACE} --all --debug
 NAME               NAMESPACE        REVISION    UPDATED                                 STATUS      CHART                       APP VERSION
 gaie-kv-events     llm-d-precise    1           2025-07-25 11:20:57.162464 -0700 PDT    deployed    inferencepool-v0.5.1        v0.5.1
 infra-kv-events    llm-d-precise    1           2025-07-25 11:20:48.115947 -0700 PDT    deployed    llm-d-infra-v1.1.1          v0.2.0
@@ -46,7 +47,7 @@ Note: if you chose to use `istio` as your Gateway provider you would see those (
 1. Find the gateway service:
 
 ```bash
-$ kubectl get services -n llm-d-precise
+$ kubectl get services -n ${NAMESPACE}
 NAME                                TYPE        CLUSTER-IP    EXTERNAL-IP   PORT(S)                      AGE
 gaie-kv-events-epp                  ClusterIP   10.16.0.249   <none>        9002/TCP,9090/TCP,5557/TCP   53s
 infra-kv-events-inference-gateway   NodePort    10.16.2.175   <none>        80:39286/TCP                 63s
@@ -57,7 +58,7 @@ In this case we have found that our gateway service is called `infra-kv-events-i
 1. `port-forward` the service so we can curl it:
 
 ```bash
-kubectl -n llm-d-precise port-forward service/infra-kv-events-inference-gateway 8000:80
+kubectl -n ${NAMESPACE} port-forward service/infra-kv-events-inference-gateway 8000:80
 ```
 
 1. Try curling the `/v1/models` endpoint:
@@ -138,7 +139,7 @@ curl -s http://localhost:8000/v1/completions \
 1. Check the inference-scheduler's prefix-cache-scorer's scores with the following command:
 
 ```bash
-kubectl logs -l inferencepool=gaie-kv-events-epp -n llm-d-precise --tail 100 | grep "Got pod scores"
+kubectl logs -l inferencepool=gaie-kv-events-epp ${NAMESPACE} --tail 100 | grep "Got pod scores"
 ```
 
 You should see output similar to:
@@ -162,7 +163,7 @@ indicating that it had cached the KV-blocks from the first call.
 1. See the `kvblock.Index` metrics in the `gaie-kv-events-epp` pod:
 
 ```bash
-kubectl logs -l inferencepool=gaie-kv-events-epp -n llm-d-precise --tail 100 | grep "metrics beat"
+kubectl logs -l inferencepool=gaie-kv-events-epp -n ${NAMESPACE} --tail 100 | grep "metrics beat"
 ```
 
 You should see output similar to:
@@ -186,7 +187,7 @@ To remove the deployment:
 helmfile --selector managedBy=helmfile destroy -f helmfile.yaml
 
 # Remove the infrastructure
-helm uninstall infra-kv-events -n llm-d-precise
+helm uninstall infra-kv-events -n ${NAMESPACE}
 ```
 
 ## Customization

--- a/quickstart/examples/precise-prefix-cache-aware/helmfile.yaml
+++ b/quickstart/examples/precise-prefix-cache-aware/helmfile.yaml
@@ -4,7 +4,6 @@ repositories:
 
 releases:
   - name: infra-kv-events
-    namespace: llm-d-precise
     chart: https://llm-d-incubation.github.io/llm-d-infra/
     version: v1.1.1
     installed: true
@@ -12,25 +11,23 @@ releases:
       managedBy: llm-d-infra-installer
 
   - name: gaie-kv-events
-    namespace: llm-d-precise
     chart: oci://registry.k8s.io/gateway-api-inference-extension/charts/inferencepool
     version: v0.5.1
     installed: true
     needs:
-      - llm-d-precise/infra-kv-events
+      - infra-kv-events
     values:
       - gaie-kv-events/values.yaml
     labels:
       managedBy: helmfile
 
   - name: ms-kv-events
-    namespace: llm-d-precise
     chart: llm-d-modelservice/llm-d-modelservice
     version: v0.2.0
     installed: true
     needs:
-      - llm-d-precise/infra-kv-events
-      - llm-d-precise/gaie-kv-events
+      - infra-kv-events
+      - gaie-kv-events
     values:
       - ms-kv-events/values.yaml
     labels:

--- a/quickstart/examples/sim/README.md
+++ b/quickstart/examples/sim/README.md
@@ -19,7 +19,8 @@ As documented in the [GIE values file](./gaie-sim/values.yaml#L4-L13), either th
 # From the repo root
 cd quickstart
 export HF_TOKEN=${HFTOKEN}
-./llmd-infra-installer.sh --namespace llm-d-sim -r infra-sim --gateway kgateway --disable-metrics-collection
+export NAMESPACE=${NAMESPACE:-llm-d-sim}
+./llmd-infra-installer.sh --namespace ${NAMESPACE} -r infra-sim --gateway kgateway --disable-metrics-collection
 ```
 
 **_NOTE:_** The release name `infra-sim` is important here, because it matches up with pre-built values files used in this example.
@@ -37,7 +38,7 @@ helmfile --selector managedBy=helmfile apply -f helmfile.yaml --skip-diff-on-ins
 1. Firstly, you should be able to list all helm releases to view all charts that should be installed:
 
    ```console
-   $ helm list -n llm-d-sim --all --debug
+   $ helm list -n ${NAMESPACE} --all --debug
    NAME         NAMESPACE    REVISION     UPDATED                                 STATUS      CHART                       APP VERSION
    gaie-sim     llm-d-sim    1           2025-07-25 10:39:08.317195 -0700 PDT    deployed    inferencepool-v0.5.1        v0.5.1
    infra-sim    llm-d-sim    1           2025-07-25 10:38:48.360829 -0700 PDT    deployed    llm-d-infra-v1.1.1          v0.2.0
@@ -49,7 +50,7 @@ helmfile --selector managedBy=helmfile apply -f helmfile.yaml --skip-diff-on-ins
 1. Find the gateway service:
 
    ```console
-   $ kubectl get services -n llm-d-sim
+   $ kubectl get services -n ${NAMESPACE}
    NAME                          TYPE        CLUSTER-IP    EXTERNAL-IP   PORT(S)             AGE
    gaie-sim-epp                  ClusterIP   10.16.2.6     <none>        9002/TCP,9090/TCP   42s
    infra-sim-inference-gateway   NodePort    10.16.2.157   <none>        80:37479/TCP        64s
@@ -60,7 +61,7 @@ helmfile --selector managedBy=helmfile apply -f helmfile.yaml --skip-diff-on-ins
 1. `port-forward` the service so we can curl it:
 
    ```bash
-   kubectl port-forward -n llm-d-sim service/infra-sim-inference-gateway 8000:80
+   kubectl port-forward -n ${NAMESPACE} service/infra-sim-inference-gateway 8000:80
    ```
 
 1. Try curling the `/v1/models` endpoint:
@@ -133,7 +134,7 @@ To remove the deployment:
 helmfile --selector managedBy=helmfile destroy -f helmfile.yaml
 
 # Remove the infrastructure
-helm uninstall infra-sim -n llm-d-sim
+helm uninstall infra-sim -n ${NAMESPACE}
 ```
 
 ## Customization

--- a/quickstart/examples/sim/helmfile.yaml
+++ b/quickstart/examples/sim/helmfile.yaml
@@ -4,7 +4,6 @@ repositories:
 
 releases:
   - name: infra-sim
-    namespace: llm-d-sim
     chart: https://llm-d-incubation.github.io/llm-d-infra/
     version: v1.1.1
     installed: true
@@ -12,25 +11,23 @@ releases:
       managedBy: llm-d-infra-installer
 
   - name: gaie-sim
-    namespace: llm-d-sim
     chart: oci://registry.k8s.io/gateway-api-inference-extension/charts/inferencepool
     version: v0.5.1
     installed: true
     needs:
-      - llm-d-sim/infra-sim
+      - infra-sim
     values:
       - gaie-sim/values.yaml
     labels:
       managedBy: helmfile
 
   - name: ms-sim
-    namespace: llm-d-sim
     chart: llm-d-modelservice/llm-d-modelservice
     version: v0.2.0
     installed: true
     needs:
-      - llm-d-sim/infra-sim
-      - llm-d-sim/gaie-sim
+      - infra-sim
+      - gaie-sim
     values:
       - ms-sim/values.yaml
     labels:

--- a/quickstart/examples/wide-ep-lws/helmfile.yaml
+++ b/quickstart/examples/wide-ep-lws/helmfile.yaml
@@ -4,7 +4,6 @@ repositories:
 
 releases:
   - name: infra-wide-ep
-    namespace: llm-d-wide-ep
     chart: https://llm-d-incubation.github.io/llm-d-infra/
     version: v1.1.1
     installed: true
@@ -14,25 +13,12 @@ releases:
       managedBy: llm-d-infra-installer
 
   - name: ms-wide-ep
-    namespace: llm-d-wide-ep
     chart: llm-d-modelservice/llm-d-modelservice
     version: v0.2.0
     installed: true
     needs:
-      - llm-d-wide-ep/infra-wide-ep
+      - infra-wide-ep
     values:
       - ms-wide-ep/values.yaml
     labels:
       managedBy: helmfile
-
-    hooks:
-    - events: [ "postsync" ]
-      command: bash
-      args:
-        - -c
-        - |
-          echo "Patching HTTPRoute to trigger reconciliation..."
-          kubectl patch httproute ms-wide-ep-llm-d-modelservice \
-            -n llm-d-wide-ep \
-            -p '{"metadata":{"labels":{"inferencepool":"ms-wide-ep"}}}' \
-            --type=merge

--- a/quickstart/examples/wide-ep-lws/infra-wide-ep/values.yaml
+++ b/quickstart/examples/wide-ep-lws/infra-wide-ep/values.yaml
@@ -11,7 +11,7 @@ gateway:
         memory: 1Gi
   destinationRule:
     enabled: true
-    host: ms-wide-ep-llm-d-modelservice-epp.llm-d-wide-ep.svc.cluster.local
+    host: ms-wide-ep-llm-d-modelservice-epp.svc.cluster.local # THIS WILL NEED TO BE ADDRESS UPSTREAM GIE I THINK
     trafficPolicy:
       connectionPool:
         http:


### PR DESCRIPTION
cc @nerdalert. This is not ready yet, we need to figure out how to do the Istio destinationRule. The host has to be namespaced scoped to allow concurrency otherwise each instance needs to be uniquely named across the cluster which is a bad practice