### PR TITLE
making a unique trigger command

### DIFF
--- a/.github/workflows/e2e-accelerator-test.yaml
+++ b/.github/workflows/e2e-accelerator-test.yaml
@@ -2,7 +2,7 @@ name: E2E Accelerator EC2 Test
 
 on:
   issue_comment:
-    # Runs with a PR comment /run-e2e or /run-e2e-istio
+    # Runs with a PR comment /run-e2e-precise-and-scheduling or /run-e2e-precise-and-scheduling-istio
     types: [created]
 #  schedule: # TODO: enable once validated functional
 #    - cron: '0 8 * * *'  # 4AM Eastern (08:00 UTC)
@@ -38,8 +38,8 @@ jobs:
         github.event_name == 'issue_comment' &&
         github.event.issue.pull_request &&
         (
-          contains(github.event.comment.body, '/run-e2e') ||
-          contains(github.event.comment.body, '/run-e2e-istio')
+          contains(github.event.comment.body, '/run-e2e-precise-and-scheduling') ||
+          contains(github.event.comment.body, '/run-e2e-precise-and-scheduling-istio')
         ) &&
         (
           github.event.comment.author_association == 'OWNER' ||
@@ -63,7 +63,7 @@ jobs:
       PR_OR_BRANCH: ${{ github.event.inputs.pr_or_branch || github.event.issue.number }}
       NAMESPACE: ${{ github.event.inputs.namespace }}
       GATEWAY_TYPE: ${{ github.event.inputs.gateway_type ||
-        (contains(github.event.comment.body || '', '/run-e2e-istio') && 'istio') ||
+        (contains(github.event.comment.body || '', '/run-e2e-precise-and-scheduling-istio') && 'istio') ||
         'kgateway' }}
 
     steps:


### PR DESCRIPTION
cc @nerdalert. When I am using the the other targets: `\/run-e2e-...` (I have escaped it here so as not to trigger a run), the run-e2e is within all other commands as its prefix. As a result it runs both scheduling + prefix + what other one you want to trigger (either pd or wide-ep). This results in:
```
An error occurred (VcpuLimitExceeded) when calling the RunInstances operation: You have requested more vCPU capacity than your current vCPU limit of 64 allows for the instance bucket that the specified instance type belongs to. Please visit http://aws.amazon.com/contact-us/ec2-request to request an adjustment to this limit.
```
Instantly from the job, and it will exit.

For now I have remapped the command to `run-e2e-precise-and-scheduling`. We can figure out a better name later