### PR TITLE
updated quickstart examples with some GIE related changes

### DIFF
--- a/quickstart/examples/inference-scheduling/gaie-inference-scheduling/values.yaml
+++ b/quickstart/examples/inference-scheduling/gaie-inference-scheduling/values.yaml
@@ -1,22 +1,12 @@
 inferenceExtension:
   replicas: 1
   image:
-    # Either image will work, you just need to bring the correct plugins per image. In this example we will bring the upstream default plugin
-    ###################
     name: llm-d-inference-scheduler
     hub: ghcr.io/llm-d
     tag: v0.2.1
-    ###################
-    # name: epp
-    # hub: registry.k8s.io/gateway-api-inference-extension
-    # tag: v0.5.1
-    ###################
     pullPolicy: Always
   extProcPort: 9002
-  # The plugins-v2.yaml contains the approximate prefix aware plugin configuration.
-  # https://github.com/kubernetes-sigs/gateway-api-inference-extension/blob/978c23bb96cce25f11cea2421523cb479026e2e9/config/charts/inferencepool/templates/epp-config.yaml#L57
-  # This will become the default in the next gaie release.
-  pluginsConfigFile: "plugins-v2.yaml"
+  pluginsConfigFile: "default-plugins.yaml" # using upstream GIE default-plugins, see: https://github.com/kubernetes-sigs/gateway-api-inference-extension/blob/main/config/charts/inferencepool/templates/epp-config.yaml#L7C3-L56C33
 inferencePool:
   targetPortNumber: 8000
   modelServerType: vllm

--- a/quickstart/examples/precise-prefix-cache-aware/gaie-kv-events/values.yaml
+++ b/quickstart/examples/precise-prefix-cache-aware/gaie-kv-events/values.yaml
@@ -1,16 +1,9 @@
 inferenceExtension:
   replicas: 1
   image:
-    # In the precise example, either image will work
-    ###################
     name: llm-d-inference-scheduler
     hub: ghcr.io/llm-d
     tag: v0.2.1
-    ###################
-    # name: epp
-    # hub: registry.k8s.io/gateway-api-inference-extension
-    # tag: v0.5.1
-    ###################
     pullPolicy: Always
   extProcPort: 9002
   # ZMQ port for `kvevents.Pool` (KVEvents subscriber)
@@ -31,7 +24,6 @@ inferenceExtension:
           name: llm-d-hf-token
           key: HF_TOKEN
   logVerbosity: 4
-
   pluginsConfigFile: "prefix-cache-tracking-config.yaml"
   pluginsCustomConfig:
     prefix-cache-tracking-config.yaml: |
@@ -49,7 +41,7 @@ inferenceExtension:
               kvBlockIndexConfig:
                 enableMetrics: true                   # enable kv-block index metrics (prometheus)
                 metricsLoggingInterval: 60000000000   # log kv-block metrics as well (1m in nanoseconds)
-        - type: kv-cache-scorer # kv-cache-utilization
+        - type: kv-cache-utilization-scorer
         - type: queue-scorer
         - type: max-score-picker
       schedulingProfiles:
@@ -57,7 +49,7 @@ inferenceExtension:
           plugins:
             - pluginRef: prefix-cache-scorer
               weight: 2.0
-            - pluginRef: kv-cache-scorer
+            - pluginRef: kv-cache-utilization-scorer
               weight: 1.0
             - pluginRef: queue-scorer
               weight: 1.0

--- a/quickstart/examples/sim/gaie-sim/values.yaml
+++ b/quickstart/examples/sim/gaie-sim/values.yaml
@@ -1,16 +1,9 @@
 inferenceExtension:
   replicas: 1
   image:
-    # Either image will work, you just need to bring the correct plugins per image. In this example we will bring the upstream default plugin
-    ###################
-    # name: llm-d-inference-scheduler
-    # hub: ghcr.io/llm-d
-    # tag: v0.2.1
-    ###################
-    name: epp
-    hub: registry.k8s.io/gateway-api-inference-extension
-    tag:  v0.5.1
-    ###################
+    name: llm-d-inference-scheduler
+    hub: ghcr.io/llm-d
+    tag: v0.2.1
     pullPolicy: Always
   extProcPort: 9002
   pluginsConfigFile: "default-plugins.yaml" # using upstream GIE default-plugins, see: https://github.com/kubernetes-sigs/gateway-api-inference-extension/blob/main/config/charts/inferencepool/templates/epp-config.yaml#L7C3-L56C33


### PR DESCRIPTION
This PR handles few minor changes in quickstart examples:
- `kv-cache-scorer` was updated in GIE to `kv-cache-utilization-scorer`.
- in some of the examples, a documentation specifying one can use either llm-d scheduler image OR GIE image is similar. in most of the cases that's not correct and we want to avoid the confusion of users keep asking us about the differences.
in llm-d we should always use llm-d images unless there is a good reason not to do so. (e.g., if in the future everything will be consolidated into GIE).
- GIE doesn't contain `plugins-v2.yaml` anymore. updated that section to point to `default-plugins.yaml`.


cc: @Gregory-Pereira @vMaroon 