### PR TITLE
removing manual YQ install

### DIFF
--- a/.github/workflows/e2e-accelerator-test.yaml
+++ b/.github/workflows/e2e-accelerator-test.yaml
@@ -172,7 +172,7 @@ jobs:
             set -x
 
             sudo apt-get update -y
-            sudo apt-get install -y git yq
+            sudo apt-get install -y git
 
             REPO_URL="https://github.com/llm-d-incubation/llm-d-infra.git"
             REPO_DIR=$(basename "$REPO_URL" .git)

--- a/.github/workflows/e2e-pd-disaggregation-accelerator-test.yaml
+++ b/.github/workflows/e2e-pd-disaggregation-accelerator-test.yaml
@@ -170,7 +170,7 @@ jobs:
             set -x
 
             sudo apt-get update -y
-            sudo apt-get install -y git yq
+            sudo apt-get install -y git
 
             # Install yq for YAML processing
             echo "Installing yq..."

--- a/.github/workflows/e2e-wide-ep-accelerator-test.yaml
+++ b/.github/workflows/e2e-wide-ep-accelerator-test.yaml
@@ -170,7 +170,7 @@ jobs:
             set -x
 
             sudo apt-get update -y
-            sudo apt-get install -y git yq
+            sudo apt-get install -y git
 
             # Install yq for YAML processing
             echo "Installing yq..."


### PR DESCRIPTION
cc @nerdalert I broke this with the last PR:
```
 tee /home/ubuntu/install-deps.log
Detected yq is not mikefarah’s yq. Please uninstall your current yq and re-run this script.
```
This is because im natively relying on apt-get yq which is python based rather than using the deps installer