### PR TITLE
removing remaining issue comment triggers from accellerator E2Es

### DIFF
--- a/.github/workflows/e2e-accelerator-test.yaml
+++ b/.github/workflows/e2e-accelerator-test.yaml
@@ -1,9 +1,6 @@
 name: E2E Accelerator EC2 Test
 
 on:
-  issue_comment:
-    # Runs with a PR comment /run-e2e-precise-and-scheduling or /run-e2e-precise-and-scheduling-istio
-    types: [created]
 #  schedule: # TODO: enable once validated functional
 #    - cron: '0 8 * * *'  # 4AM Eastern (08:00 UTC)
   workflow_dispatch:

--- a/.github/workflows/e2e-pd-disaggregation-accelerator-test.yaml
+++ b/.github/workflows/e2e-pd-disaggregation-accelerator-test.yaml
@@ -1,9 +1,6 @@
 name: E2E PD-Disaggregation Test
 
 on:
-  issue_comment:
-    # Runs with a PR comment /run-e2e-pd or /run-e2e-pd-istio
-    types: [created]
   workflow_dispatch:
     inputs:
       pr_or_branch:

--- a/.github/workflows/e2e-wide-ep-accelerator-test.yaml
+++ b/.github/workflows/e2e-wide-ep-accelerator-test.yaml
@@ -1,9 +1,6 @@
 name: E2E Wide EP Test
 
 on:
-  issue_comment:
-    # Runs with a PR comment /run-e2e-wide-ep
-    types: [created]
   workflow_dispatch:
     inputs:
       pr_or_branch:


### PR DESCRIPTION
Only use workflow dispatch
cc @nerdalert 