### PR TITLE
add epp servicemonitor to examples

### DIFF
--- a/quickstart/examples/inference-scheduling/gaie-inference-scheduling/values.yaml
+++ b/quickstart/examples/inference-scheduling/gaie-inference-scheduling/values.yaml
@@ -17,6 +17,12 @@ inferenceExtension:
   # https://github.com/kubernetes-sigs/gateway-api-inference-extension/blob/978c23bb96cce25f11cea2421523cb479026e2e9/config/charts/inferencepool/templates/epp-config.yaml#L57
   # This will become the default in the next gaie release.
   pluginsConfigFile: "plugins-v2.yaml"
+  monitoring:
+    servicemonitor:
+      enabled: false
+      port: "http-metrics"
+      path: "/metrics"
+      interval: "10s"
 inferencePool:
   targetPortNumber: 8000
   modelServerType: vllm

--- a/quickstart/examples/pd-disaggregation/gaie-pd/values.yaml
+++ b/quickstart/examples/pd-disaggregation/gaie-pd/values.yaml
@@ -6,6 +6,13 @@ inferenceExtension:
     hub: ghcr.io/llm-d
     tag: v0.2.1
     pullPolicy: Always
+  # Monitoring configuration for EPP
+  monitoring:
+    servicemonitor:
+      enabled: false
+      port: "http-metrics"
+      path: "/metrics"
+      interval: "10s"
   extProcPort: 9002
   pluginsConfigFile: "pd-config.yaml"
   logVerbosity: 1

--- a/quickstart/examples/precise-prefix-cache-aware/gaie-kv-events/values.yaml
+++ b/quickstart/examples/precise-prefix-cache-aware/gaie-kv-events/values.yaml
@@ -12,6 +12,13 @@ inferenceExtension:
     # tag: v0.5.1
     ###################
     pullPolicy: Always
+  # Monitoring configuration for EPP
+  monitoring:
+    servicemonitor:
+      enabled: false
+      port: "http-metrics"
+      path: "/metrics"
+      interval: "10s"
   extProcPort: 9002
   # ZMQ port for `kvevents.Pool` (KVEvents subscriber)
   extraContainerPorts:

--- a/quickstart/examples/sim/gaie-sim/values.yaml
+++ b/quickstart/examples/sim/gaie-sim/values.yaml
@@ -12,6 +12,13 @@ inferenceExtension:
     tag:  v0.5.1
     ###################
     pullPolicy: Always
+  # Monitoring configuration for EPP
+  monitoring:
+    servicemonitor:
+      enabled: false
+      port: "http-metrics"
+      path: "/metrics"
+      interval: "10s"
   extProcPort: 9002
   pluginsConfigFile: "default-plugins.yaml" # using upstream GIE default-plugins, see: https://github.com/kubernetes-sigs/gateway-api-inference-extension/blob/main/config/charts/inferencepool/templates/epp-config.yaml#L7C3-L56C33
 inferencePool:

--- a/quickstart/examples/wide-ep-lws/ms-wide-ep/values.yaml
+++ b/quickstart/examples/wide-ep-lws/ms-wide-ep/values.yaml
@@ -35,6 +35,12 @@ routing:
     image: ghcr.io/llm-d/llm-d-inference-scheduler:v0.2.1
     debugLevel: 1
     pluginsConfigFile: "pd-config.yaml"
+    monitoring:
+      servicemonitor:
+        enabled: false
+        port: "http-metrics"  # EPP service port for metrics
+        path: "/metrics"
+        interval: "30s"
     pluginsCustomConfig:
       pd-config.yaml: |
         # ALWAYS DO PD IN THIS EXAMPLE (THRESHOLD 0)


### PR DESCRIPTION
This PR adds EPP servicemonitors to quickstart examples.

This PR depends on:
llm-d-modelservice charts: https://github.com/llm-d-incubation/llm-d-modelservice/pull/87
gateway-api-inference-extension charts: https://github.com/kubernetes-sigs/gateway-api-inference-extension/pull/1425

Do not merge until the above PRs are merged.