### PR TITLE
quickstart infra bump + fixing concurrency + removing ns env var

### DIFF
--- a/quickstart/examples/inference-scheduling/README.md
+++ b/quickstart/examples/inference-scheduling/README.md
@@ -28,7 +28,7 @@ cd quickstart/examples/inference-scheduling
 helmfile apply -n ${NAMESPACE}
 ```
 
-**_NOTE:_** You can set the `$RELEASE_NAME_POSTFIX` env variable to change the release names. This is how we support concurrent installs.
+**_NOTE:_** You can set the `$RELEASE_NAME_POSTFIX` env variable to change the release names. This is how we support concurrent installs. Ex: `RELEASE_NAME_POSTFIX=inference-scheduling-2 helmfile apply -n ${NAMESPACE}`
 
 **_NOTE:_** This uses Istio as the default provider, see [Gateway Options](./README.md#gateway-options) for installing with a specific provider.
 

--- a/quickstart/examples/inference-scheduling/README.md
+++ b/quickstart/examples/inference-scheduling/README.md
@@ -25,8 +25,10 @@ Use the helmfile to compose and install the stack. The Namespace in which the st
 ```bash
 export NAMESPACE=llm-d-inference-scheduler # or any other namespace
 cd quickstart/examples/inference-scheduling
-helmfile apply
+helmfile apply -n ${NAMESPACE}
 ```
+
+**_NOTE:_** You can set the `$RELEASE_NAME_POSTFIX` env variable to change the release names. This is how we support concurrent installs.
 
 **_NOTE:_** This uses Istio as the default provider, see [Gateway Options](./README.md#gateway-options) for installing with a specific provider.
 
@@ -35,7 +37,7 @@ helmfile apply
 To see specify your gateway choice you can use the `-e <gateway option>` flag, ex:
 
 ```bash
-helmfile apply -e kgateway
+helmfile apply -e kgateway -n ${NAMESPACE}
 ```
 
 To see what gateway options are supported refer to our [gateway control plane docs](../../gateway-control-plane-providers/README.md#supported-providers). Gateway configurations per provider are tracked in the [gateway-configurations directory](../common/gateway-configurations/).
@@ -92,7 +94,7 @@ To remove the deployment:
 
 ```bash
 # From examples/inference-scheduling
-helmfile destroy
+helmfile destroy -n ${NAMESPACE}
 
 # Or uninstall manually
 helm uninstall infra-inference-scheduling -n ${NAMESPACE}
@@ -102,7 +104,7 @@ helm uninstall ms-inference-scheduling -n ${NAMESPACE}
 
 **_NOTE:_** If you set the `$RELEASE_NAME_POSTFIX` environment variable, your release names will be different from the command above: `infra-$RELEASE_NAME_POSTFIX`, `gaie-$RELEASE_NAME_POSTFIX` and `ms-$RELEASE_NAME_POSTFIX`.
 
-**_NOTE:_** You do not need to specify your `environment` with the `-e <environment>` flag to `helmfile` for removing a installation of the quickstart, even if you use a non-default option.
+**_NOTE:_** You do not need to specify your `environment` with the `-e <environment>` flag to `helmfile` for removing a installation of the quickstart, even if you use a non-default option. You do, however, have to set the `-n ${NAMESPACE}` otherwise it may not cleanup the releases in the proper namespace.
 
 ## Customization
 

--- a/quickstart/examples/inference-scheduling/helmfile.yaml.gotmpl
+++ b/quickstart/examples/inference-scheduling/helmfile.yaml.gotmpl
@@ -67,7 +67,7 @@ releases:
       - ms-inference-scheduling/values.yaml
     set:
     # apply release name derived values
-      - name: "inferencePool.name"
+      - name: "routing.inferencePool.name"
         value: {{ printf "gaie-%s" $rn | quote }}
       - name: "routing.parentRefs[0].name"
         value: {{ printf "infra-%s-inference-gateway" $rn | quote }}

--- a/quickstart/examples/inference-scheduling/helmfile.yaml.gotmpl
+++ b/quickstart/examples/inference-scheduling/helmfile.yaml.gotmpl
@@ -13,7 +13,7 @@ environments:
 
 ---
 
-{{- $ns := (env "NAMESPACE") | default "llm-d-inference-scheduler" -}}
+{{- $ns := .Namespace | default "llm-d-inference-scheduler" -}}
 {{- $rn := (env "RELEASE_NAME_POSTFIX") | default "inference-scheduling" -}}
 
 # set $ns as namespace for all releases
@@ -27,8 +27,9 @@ repositories:
 
 releases:
   - name: {{ printf "infra-%s" $rn | quote }}
+    namespace: {{ $ns }}
     chart: llm-d-infra/llm-d-infra
-    version: v1.2.4
+    version: v1.3.0
     installed: true
     labels:
       type: infrastructure
@@ -40,6 +41,7 @@ releases:
             host: {{ printf "gaie-inference-scheduling-epp.%s.svc.cluster.local" $ns | quote }}
 
   - name: {{ printf "gaie-%s" $rn | quote }}
+    namespace: {{ $ns }}
     chart: oci://registry.k8s.io/gateway-api-inference-extension/charts/inferencepool
     version: v0.5.1
     installed: true
@@ -54,6 +56,7 @@ releases:
       kind: inference-stack
 
   - name: {{ printf "ms-%s" $rn | quote }}
+    namespace: {{ $ns }}
     chart: llm-d-modelservice/llm-d-modelservice
     version: v0.2.7
     installed: true
@@ -62,5 +65,11 @@ releases:
       - {{ printf "gaie-%s" $rn | quote }}
     values:
       - ms-inference-scheduling/values.yaml
+    set:
+    # apply release name derived values
+      - name: "inferencePool.name"
+        value: {{ printf "gaie-%s" $rn | quote }}
+      - name: "routing.parentRefs[0].name"
+        value: {{ printf "infra-%s-inference-gateway" $rn | quote }}
     labels:
       kind: inference-stack

--- a/quickstart/examples/inference-scheduling/ms-inference-scheduling/values.yaml
+++ b/quickstart/examples/inference-scheduling/ms-inference-scheduling/values.yaml
@@ -12,7 +12,7 @@ routing:
   parentRefs:
     - group: gateway.networking.k8s.io
       kind: Gateway
-      name: infra-inference-scheduling-inference-gateway
+      # name: infra-inference-scheduling-inference-gateway # set in helmfile
 
   proxy:
     image: ghcr.io/llm-d/llm-d-routing-sidecar:v0.2.0
@@ -24,7 +24,7 @@ routing:
 
   inferencePool:
     create: false
-    name: gaie-inference-scheduling
+    # name: gaie-inference-scheduling # set in helmfile
 
   httpRoute:
     create: true

--- a/quickstart/examples/pd-disaggregation/README.md
+++ b/quickstart/examples/pd-disaggregation/README.md
@@ -52,7 +52,7 @@ cd quickstart/examples/pd-disaggregation
 helmfile apply -n ${NAMESPACE}
 ```
 
-**_NOTE:_** You can set the `$RELEASE_NAME_POSTFIX` env variable to change the release names. This is how we support concurrent installs.
+**_NOTE:_** You can set the `$RELEASE_NAME_POSTFIX` env variable to change the release names. This is how we support concurrent installs. Ex: `RELEASE_NAME_POSTFIX=pd-2 helmfile apply -n ${NAMESPACE}`
 
 **_NOTE:_** This uses Istio as the default provider, see [Gateway Options](./README.md#gateway-options) for installing with a specific provider.
 

--- a/quickstart/examples/pd-disaggregation/README.md
+++ b/quickstart/examples/pd-disaggregation/README.md
@@ -49,8 +49,10 @@ Use the helmfile to compose and install the stack. The Namespace in which the st
 ```bash
 export NAMESPACE=llm-d-pd # Or any namespace your heart desires
 cd quickstart/examples/pd-disaggregation
-helmfile apply
+helmfile apply -n ${NAMESPACE}
 ```
+
+**_NOTE:_** You can set the `$RELEASE_NAME_POSTFIX` env variable to change the release names. This is how we support concurrent installs.
 
 **_NOTE:_** This uses Istio as the default provider, see [Gateway Options](./README.md#gateway-options) for installing with a specific provider.
 
@@ -59,7 +61,7 @@ helmfile apply
 To see specify your gateway choice you can use the `-e <gateway option>` flag, ex:
 
 ```bash
-helmfile apply -e kgateway
+helmfile apply -e kgateway -n ${NAMESPACE}
 ```
 
 To see what gateway options are supported refer to our [gateway control plane docs](../../gateway-control-plane-providers/README.md#supported-providers). Gateway configurations per provider are tracked in the [gateway-configurations directory](../common/gateway-configurations/).
@@ -125,7 +127,7 @@ To remove the deployment:
 
 ```bash
 # Remove the model services
-helmfile destroy
+helmfile destroy -n ${NAMESPACE}
 
 # Remove the infrastructure
 helm uninstall ms-pd -n ${NAMESPACE}
@@ -135,7 +137,7 @@ helm uninstall infra-pd -n ${NAMESPACE}
 
 **_NOTE:_** If you set the `$RELEASE_NAME_POSTFIX` environment variable, your release names will be different from the command above: `infra-$RELEASE_NAME_POSTFIX`, `gaie-$RELEASE_NAME_POSTFIX` and `ms-$RELEASE_NAME_POSTFIX`.
 
-**_NOTE:_** You do not need to specify your `environment` with the `-e <environment>` flag to `helmfile` for removing a installation of the quickstart, even if you use a non-default option.
+**_NOTE:_** You do not need to specify your `environment` with the `-e <environment>` flag to `helmfile` for removing a installation of the quickstart, even if you use a non-default option. You do, however, have to set the `-n ${NAMESPACE}` otherwise it may not cleanup the releases in the proper namespace.
 
 ## Customization
 

--- a/quickstart/examples/pd-disaggregation/helmfile.yaml.gotmpl
+++ b/quickstart/examples/pd-disaggregation/helmfile.yaml.gotmpl
@@ -83,7 +83,7 @@ releases:
     {{- end }}
     set:
     # apply release name derived values
-      - name: "inferencePool.name"
+      - name: "routing.inferencePool.name"
         value: {{ printf "gaie-%s" $rn | quote }}
       - name: "routing.parentRefs[0].name"
         value: {{ printf "infra-%s-inference-gateway" $rn | quote }}

--- a/quickstart/examples/pd-disaggregation/helmfile.yaml.gotmpl
+++ b/quickstart/examples/pd-disaggregation/helmfile.yaml.gotmpl
@@ -17,7 +17,7 @@ environments:
 
 ---
 
-{{- $ns := (env "NAMESPACE") | default "llm-d-pd" -}}
+{{- $ns := .Namespace | default "llm-d-pd" -}}
 {{- $rn := (env "RELEASE_NAME_POSTFIX") | default "pd" -}}
 
 # set $ns as namespace for all releases
@@ -31,8 +31,9 @@ repositories:
 
 releases:
   - name: {{ printf "infra-%s" $rn | quote }}
+    namespace: {{ $ns }}
     chart: llm-d-infra/llm-d-infra
-    version: v1.2.4
+    version: v1.3.0
     installed: true
     labels:
       type: infrastructure
@@ -45,6 +46,7 @@ releases:
             host: {{ printf "gaie-pd-epp.%s.svc.cluster.local" $ns | quote }}
 
   - name: {{ printf "gaie-%s" $rn | quote }}
+    namespace: {{ $ns }}
     chart: oci://registry.k8s.io/gateway-api-inference-extension/charts/inferencepool
     version: v0.5.1
     installed: true
@@ -63,6 +65,7 @@ releases:
       kind: inference-stack
 
   - name: {{ printf "ms-%s" $rn | quote }}
+    namespace: {{ $ns }}
     chart: llm-d-modelservice/llm-d-modelservice
     version: v0.2.7
     installed: true
@@ -78,8 +81,13 @@ releases:
           epp:
             debugLevel: {{ .Environment.Values.routing.epp.debugLevel }}
     {{- end }}
-    {{- if eq .Environment.Name "gke" }}
     set:
+    # apply release name derived values
+      - name: "inferencePool.name"
+        value: {{ printf "gaie-%s" $rn | quote }}
+      - name: "routing.parentRefs[0].name"
+        value: {{ printf "infra-%s-inference-gateway" $rn | quote }}
+    {{- if eq .Environment.Name "gke" }}
       - name: "decode.containers[0].resources.limits.rdma/ib"
         value: null
       - name: "decode.containers[0].resources.requests.rdma/ib"

--- a/quickstart/examples/pd-disaggregation/ms-pd/values.yaml
+++ b/quickstart/examples/pd-disaggregation/ms-pd/values.yaml
@@ -12,7 +12,7 @@ routing:
   parentRefs:
     - group: gateway.networking.k8s.io
       kind: Gateway
-      name: infra-pd-inference-gateway # release dependent move to helmfile set
+      # name: infra-pd-inference-gateway # set in helmfile
 
   proxy:
     image: ghcr.io/llm-d/llm-d-routing-sidecar:v0.2.0
@@ -25,7 +25,7 @@ routing:
 
   inferencePool:
     create: false
-    name: gaie-pd
+    # name: gaie-pd # set in helmfile
 
   httpRoute:
     create: true

--- a/quickstart/examples/precise-prefix-cache-aware/README.md
+++ b/quickstart/examples/precise-prefix-cache-aware/README.md
@@ -19,8 +19,10 @@ Use the helmfile to compose and install the stack. The Namespace in which the st
 ```bash
 export NAMESPACE=llm-d-precise # Or any namespace your heart desires
 cd quickstart/examples/precise-prefix-cache-aware
-helmfile apply
+helmfile apply -n ${NAMESPACE}
 ```
+
+**_NOTE:_** You can set the `$RELEASE_NAME_POSTFIX` env variable to change the release names. This is how we support concurrent installs.
 
 **_NOTE:_** This uses Istio as the default provider, see [Gateway Options](./README.md#gateway-options) for installing with a specific provider.
 
@@ -29,7 +31,7 @@ helmfile apply
 To see specify your gateway choice you can use the `-e <gateway option>` flag, ex:
 
 ```bash
-helmfile apply -e kgateway
+helmfile apply -e kgateway -n ${NAMESPACE}
 ```
 
 To see what gateway options are supported refer to our [gateway control plane docs](../../gateway-control-plane-providers/README.md#supported-providers). Gateway configurations per provider are tracked in the [gateway-configurations directory](../common/gateway-configurations/).
@@ -145,7 +147,7 @@ To remove the deployment:
 ```bash
 # Remove the model services
 # From examples/precise-prefix-cache-aware
-helmfile destroy
+helmfile destroy -n ${NAMESPACE}
 
 # Or uninstall manually
 helm uninstall infra-kv-events -n ${NAMESPACE}
@@ -155,7 +157,7 @@ helm uninstall ms-kv-events -n ${NAMESPACE}
 
 **_NOTE:_** If you set the `$RELEASE_NAME_POSTFIX` environment variable, your release names will be different from the command above: `infra-$RELEASE_NAME_POSTFIX`, `gaie-$RELEASE_NAME_POSTFIX` and `ms-$RELEASE_NAME_POSTFIX`.
 
-**_NOTE:_** You do not need to specify your `environment` with the `-e <environment>` flag to `helmfile` for removing a installation of the quickstart, even if you use a non-default option.
+**_NOTE:_** You do not need to specify your `environment` with the `-e <environment>` flag to `helmfile` for removing a installation of the quickstart, even if you use a non-default option. You do, however, have to set the `-n ${NAMESPACE}` otherwise it may not cleanup the releases in the proper namespace.
 
 ## Customization
 

--- a/quickstart/examples/precise-prefix-cache-aware/README.md
+++ b/quickstart/examples/precise-prefix-cache-aware/README.md
@@ -22,7 +22,7 @@ cd quickstart/examples/precise-prefix-cache-aware
 helmfile apply -n ${NAMESPACE}
 ```
 
-**_NOTE:_** You can set the `$RELEASE_NAME_POSTFIX` env variable to change the release names. This is how we support concurrent installs.
+**_NOTE:_** You can set the `$RELEASE_NAME_POSTFIX` env variable to change the release names. This is how we support concurrent installs. Ex: `RELEASE_NAME_POSTFIX=kv-events-2 helmfile apply -n ${NAMESPACE}`
 
 **_NOTE:_** This uses Istio as the default provider, see [Gateway Options](./README.md#gateway-options) for installing with a specific provider.
 

--- a/quickstart/examples/precise-prefix-cache-aware/helmfile.yaml.gotmpl
+++ b/quickstart/examples/precise-prefix-cache-aware/helmfile.yaml.gotmpl
@@ -13,7 +13,7 @@ environments:
 
 ---
 
-{{- $ns := (env "NAMESPACE") | default "llm-d-precise" -}}
+{{- $ns := .Namespace | default "llm-d-precise" -}}
 {{- $rn := (env "RELEASE_NAME_POSTFIX") | default "kv-events" -}}
 
 # set $ns as namespace for all releases
@@ -27,8 +27,9 @@ repositories:
 
 releases:
   - name: {{ printf "infra-%s" $rn | quote }}
+    namespace: {{ $ns }}
     chart: llm-d-infra/llm-d-infra
-    version: v1.2.4
+    version: v1.3.0
     installed: true
     labels:
       type: infrastructure
@@ -40,6 +41,7 @@ releases:
             host: {{ printf "gaie-kv-events-epp.%s.svc.cluster.local" $ns | quote }}
 
   - name: {{ printf "gaie-%s" $rn | quote }}
+    namespace: {{ $ns }}
     chart: oci://registry.k8s.io/gateway-api-inference-extension/charts/inferencepool
     version: v0.5.1
     installed: true
@@ -54,6 +56,7 @@ releases:
       kind: inference-stack
 
   - name: {{ printf "ms-%s" $rn | quote }}
+    namespace: {{ $ns }}
     chart: llm-d-modelservice/llm-d-modelservice
     version: v0.2.7
     installed: true
@@ -62,5 +65,11 @@ releases:
       - {{ printf "gaie-%s" $rn | quote }}
     values:
       - ms-kv-events/values.yaml
+    set:
+    # apply release name derived values
+      - name: "inferencePool.name"
+        value: {{ printf "gaie-%s" $rn | quote }}
+      - name: "routing.parentRefs[0].name"
+        value: {{ printf "infra-%s-inference-gateway" $rn | quote }}
     labels:
       kind: inference-stack

--- a/quickstart/examples/precise-prefix-cache-aware/helmfile.yaml.gotmpl
+++ b/quickstart/examples/precise-prefix-cache-aware/helmfile.yaml.gotmpl
@@ -67,7 +67,7 @@ releases:
       - ms-kv-events/values.yaml
     set:
     # apply release name derived values
-      - name: "inferencePool.name"
+      - name: "routing.inferencePool.name"
         value: {{ printf "gaie-%s" $rn | quote }}
       - name: "routing.parentRefs[0].name"
         value: {{ printf "infra-%s-inference-gateway" $rn | quote }}

--- a/quickstart/examples/precise-prefix-cache-aware/ms-kv-events/values.yaml
+++ b/quickstart/examples/precise-prefix-cache-aware/ms-kv-events/values.yaml
@@ -12,7 +12,7 @@ routing:
   parentRefs:
     - group: gateway.networking.k8s.io
       kind: Gateway
-      name: infra-kv-events-inference-gateway
+      # name: infra-kv-events-inference-gateway # set in helmfile
 
   proxy:
     image: ghcr.io/llm-d/llm-d-routing-sidecar:v0.2.0
@@ -24,7 +24,7 @@ routing:
 
   inferencePool:
     create: false
-    name: gaie-kv-events
+    # name: gaie-kv-events # set in helmfile
 
   httpRoute:
     create: true

--- a/quickstart/examples/sim/README.md
+++ b/quickstart/examples/sim/README.md
@@ -22,7 +22,7 @@ cd quickstart/examples/sim
 helmfile apply -n ${NAMESPACE}
 ```
 
-**_NOTE:_** You can set the `$RELEASE_NAME_POSTFIX` env variable to change the release names. This is how we support concurrent installs.
+**_NOTE:_** You can set the `$RELEASE_NAME_POSTFIX` env variable to change the release names. This is how we support concurrent installs. ex: `RELEASE_NAME_POSTFIX=sim-2 helmfile apply -n ${NAMESPACE}`
 
 **_NOTE:_** This uses Istio as the default provider, see [Gateway Options](./README.md#gateway-options) for installing with a specific provider.
 

--- a/quickstart/examples/sim/README.md
+++ b/quickstart/examples/sim/README.md
@@ -19,8 +19,10 @@ Use the helmfile to compose and install the stack. The Namespace in which the st
 ```bash
 export NAMESPACE=llm-d-sim # Or any namespace your heart desires
 cd quickstart/examples/sim
-helmfile apply
+helmfile apply -n ${NAMESPACE}
 ```
+
+**_NOTE:_** You can set the `$RELEASE_NAME_POSTFIX` env variable to change the release names. This is how we support concurrent installs.
 
 **_NOTE:_** This uses Istio as the default provider, see [Gateway Options](./README.md#gateway-options) for installing with a specific provider.
 
@@ -29,7 +31,7 @@ helmfile apply
 To see specify your gateway choice you can use the `-e <gateway option>` flag, ex:
 
 ```bash
-helmfile apply -e kgateway
+helmfile apply -e kgateway -n ${NAMESPACE}
 ```
 
 To see what gateway options are supported refer to our [gateway control plane docs](../../gateway-control-plane-providers/README.md#supported-providers). Gateway configurations per provider are tracked in the [gateway-configurations directory](../common/gateway-configurations/).
@@ -90,7 +92,7 @@ To remove the deployment:
 
 ```bash
 # From examples/sim
-helmfile destroy
+helmfile destroy -n ${NAMESPACE}
 
 # Or uninstall manually
 helm uninstall infra-sim -n ${NAMESPACE}
@@ -100,7 +102,7 @@ helm uninstall ms-sim -n ${NAMESPACE}
 
 **_NOTE:_** If you set the `$RELEASE_NAME_POSTFIX` environment variable, your release names will be different from the command above: `infra-$RELEASE_NAME_POSTFIX`, `gaie-$RELEASE_NAME_POSTFIX` and `ms-$RELEASE_NAME_POSTFIX`.
 
-**_NOTE:_** You do not need to specify your `environment` with the `-e <environment>` flag to `helmfile` for removing a installation of the quickstart, even if you use a non-default option.
+**_NOTE:_** You do not need to specify your `environment` with the `-e <environment>` flag to `helmfile` for removing a installation of the quickstart, even if you use a non-default option. You do, however, have to set the `-n ${NAMESPACE}` otherwise it may not cleanup the releases in the proper namespace.
 
 ## Customization
 

--- a/quickstart/examples/sim/helmfile.yaml.gotmpl
+++ b/quickstart/examples/sim/helmfile.yaml.gotmpl
@@ -43,7 +43,7 @@ releases:
     version: v0.5.1
     installed: true
     needs:
-      - infra-sim
+      - {{ printf "infra-%s" $rn | quote }}
     values:
       - gaie-sim/values.yaml
     {{- if eq .Environment.Name "gke" }}
@@ -58,13 +58,13 @@ releases:
     version: v0.2.7
     installed: true
     needs:
-      - infra-sim
-      - gaie-sim
+      - {{ printf "infra-%s" $rn | quote }}
+      - {{ printf "gaie-%s" $rn | quote }}
     values:
       - ms-sim/values.yaml
     set:
     # apply release name derived values
-      - name: "inferencePool.name"
+      - name: "routing.inferencePool.name"
         value: {{ printf "gaie-%s" $rn | quote }}
       - name: "routing.parentRefs[0].name"
         value: {{ printf "infra-%s-inference-gateway" $rn | quote }}

--- a/quickstart/examples/sim/helmfile.yaml.gotmpl
+++ b/quickstart/examples/sim/helmfile.yaml.gotmpl
@@ -13,11 +13,8 @@ environments:
 
 ---
 
-{{- $ns := (env "NAMESPACE") | default "llm-d-sim" -}}
+{{- $ns := .Namespace | default "llm-d-sim" -}}
 {{- $rn := (env "RELEASE_NAME_POSTFIX") | default "sim" -}}
-
-# set $ns as namespace for all releases
-namespace: {{ $ns }}
 
 repositories:
   - name: llm-d-modelservice
@@ -27,8 +24,9 @@ repositories:
 
 releases:
   - name: {{ printf "infra-%s" $rn | quote }}
+    namespace: {{ $ns }}
     chart: llm-d-infra/llm-d-infra
-    version: v1.2.4
+    version: v1.3.0
     installed: true
     labels:
       type: infrastructure
@@ -40,7 +38,7 @@ releases:
             host: {{ printf "gaie-sim-epp.%s.svc.cluster.local" $ns | quote }}
 
   - name: {{ printf "gaie-%s" $rn | quote }}
-    namespace: llm-d-sim
+    namespace: {{ $ns }}
     chart: oci://registry.k8s.io/gateway-api-inference-extension/charts/inferencepool
     version: v0.5.1
     installed: true
@@ -55,7 +53,7 @@ releases:
       kind: inference-stack
 
   - name: {{ printf "ms-%s" $rn | quote }}
-    namespace: llm-d-sim
+    namespace: {{ $ns }}
     chart: llm-d-modelservice/llm-d-modelservice
     version: v0.2.7
     installed: true
@@ -64,5 +62,11 @@ releases:
       - gaie-sim
     values:
       - ms-sim/values.yaml
+    set:
+    # apply release name derived values
+      - name: "inferencePool.name"
+        value: {{ printf "gaie-%s" $rn | quote }}
+      - name: "routing.parentRefs[0].name"
+        value: {{ printf "infra-%s-inference-gateway" $rn | quote }}
     labels:
       kind: inference-stack

--- a/quickstart/examples/sim/ms-sim/values.yaml
+++ b/quickstart/examples/sim/ms-sim/values.yaml
@@ -11,7 +11,7 @@ routing:
   parentRefs:
     - group: gateway.networking.k8s.io
       kind: Gateway
-      name: infra-sim-inference-gateway
+      # name: infra-sim-inference-gateway # set in helmfile
 
   proxy:
     image: ghcr.io/llm-d/llm-d-routing-sidecar:v0.2.0
@@ -23,7 +23,7 @@ routing:
 
   inferencePool:
     create: false
-    name: gaie-sim
+    # name: gaie-sim # set in helmfile
 
   httpRoute:
     create: true

--- a/quickstart/examples/wide-ep-lws/README.md
+++ b/quickstart/examples/wide-ep-lws/README.md
@@ -31,8 +31,10 @@ Use the helmfile to compose and install the stack. The Namespace in which the st
 ```bash
 export NAMESPACE=llm-d-wide-ep # or any other namespace
 cd quickstart/examples/wide-ep-lws
-helmfile apply
+helmfile apply -n ${NAMESPACE}
 ```
+
+**_NOTE:_** You can set the `$RELEASE_NAME_POSTFIX` env variable to change the release names. This is how we support concurrent installs.
 
 **_NOTE:_** This uses Istio as the default provider, see [Gateway Options](./README.md#gateway-options) for installing with a specific provider.
 
@@ -41,7 +43,7 @@ helmfile apply
 To see specify your gateway choice you can use the `-e <gateway option>` flag, ex:
 
 ```bash
-helmfile apply -e kgateway
+helmfile apply -e kgateway -n ${NAMESPACe}
 ```
 
 To see what gateway options are supported refer to our [gateway control plane docs](../../gateway-control-plane-providers/README.md#supported-providers). Gateway configurations per provider are tracked in the [gateway-configurations directory](../common/gateway-configurations/).
@@ -107,7 +109,7 @@ To remove the deployment:
 
 ```bash
 # From examples/wide-ep-lws
-helmfile destroy
+helmfile destroy -n ${NAMESPACE}
 
 # Or uninstall them manually
 helm uninstall ms-wide-ep -n ${NAMESPACE}

--- a/quickstart/examples/wide-ep-lws/README.md
+++ b/quickstart/examples/wide-ep-lws/README.md
@@ -34,7 +34,7 @@ cd quickstart/examples/wide-ep-lws
 helmfile apply -n ${NAMESPACE}
 ```
 
-**_NOTE:_** You can set the `$RELEASE_NAME_POSTFIX` env variable to change the release names. This is how we support concurrent installs.
+**_NOTE:_** You can set the `$RELEASE_NAME_POSTFIX` env variable to change the release names. This is how we support concurrent installs. Ex: `RELEASE_NAME_POSTFIX=wide-ep-2 helmfile apply -n ${NAMESPACE}`
 
 **_NOTE:_** This uses Istio as the default provider, see [Gateway Options](./README.md#gateway-options) for installing with a specific provider.
 

--- a/quickstart/examples/wide-ep-lws/helmfile.yaml.gotmpl
+++ b/quickstart/examples/wide-ep-lws/helmfile.yaml.gotmpl
@@ -17,11 +17,8 @@ environments:
 
 ---
 
-{{- $ns := (env "NAMESPACE") | default "llm-d-wide-ep" -}}
+{{- $ns := .Namespace | default "llm-d-wide-ep" }}
 {{- $rn := (env "RELEASE_NAME_POSTFIX") | default "wide-ep" -}}
-
-# set $ns as namespace for all releases
-namespace: {{ $ns }}
 
 repositories:
   - name: llm-d-modelservice
@@ -31,8 +28,9 @@ repositories:
 
 releases:
   - name: {{ printf "infra-%s" $rn | quote }}
+    namespace: {{ $ns }}
     chart: llm-d-infra/llm-d-infra
-    version: v1.2.4
+    version: v1.3.0
     installed: true
     labels:
       type: infrastructure
@@ -46,6 +44,7 @@ releases:
 
   - name: {{ printf "ms-%s" $rn | quote }}
     chart: llm-d-modelservice/llm-d-modelservice
+    namespace: {{ $ns }}
     version: v0.2.7
     installed: true
     needs:
@@ -59,8 +58,13 @@ releases:
           epp:
             debugLevel: {{ .Environment.Values.routing.epp.debugLevel }}
     {{- end }}
-    {{- if eq .Environment.Name "gke" }}
     set:
+    # apply release name derived values
+      - name: "inferencePool.name"
+        value: {{ printf "ms-%s" $rn | quote }}
+      - name: "routing.parentRefs[0].name"
+        value: {{ printf "infra-%s-inference-gateway" $rn | quote }}
+    {{- if eq .Environment.Name "gke" }}
       - name: "decode.containers[0].resources.limits.rdma/ib"
         value: null
       - name: "decode.containers[0].resources.requests.rdma/ib"

--- a/quickstart/examples/wide-ep-lws/helmfile.yaml.gotmpl
+++ b/quickstart/examples/wide-ep-lws/helmfile.yaml.gotmpl
@@ -43,8 +43,8 @@ releases:
             host: {{ printf "ms-wide-ep-llm-d-modelservice-epp.%s.svc.cluster.local" $ns | quote }}
 
   - name: {{ printf "ms-%s" $rn | quote }}
-    chart: llm-d-modelservice/llm-d-modelservice
     namespace: {{ $ns }}
+    chart: llm-d-modelservice/llm-d-modelservice
     version: v0.2.7
     installed: true
     needs:
@@ -60,7 +60,7 @@ releases:
     {{- end }}
     set:
     # apply release name derived values
-      - name: "inferencePool.name"
+      - name: "routing.inferencePool.name"
         value: {{ printf "ms-%s" $rn | quote }}
       - name: "routing.parentRefs[0].name"
         value: {{ printf "infra-%s-inference-gateway" $rn | quote }}

--- a/quickstart/examples/wide-ep-lws/ms-wide-ep/values.yaml
+++ b/quickstart/examples/wide-ep-lws/ms-wide-ep/values.yaml
@@ -12,7 +12,7 @@ routing:
   parentRefs:
     - group: gateway.networking.k8s.io
       kind: Gateway
-      name: infra-wide-ep-inference-gateway
+      # name: infra-wide-ep-inference-gateway # set in helmfile
 
   proxy:
     image: "ghcr.io/llm-d/llm-d-routing-sidecar:v0.2.0"
@@ -25,7 +25,7 @@ routing:
 
   inferencePool:
     create: true
-    name: ms-wide-ep
+    # name: ms-wide-ep # set in helmfile
 
   httpRoute:
     create: true


### PR DESCRIPTION
changes:
- namespace now has to be passed via the `--namespace` flag, if not the default will get used, but this means  we dont need to track the value of the $NAMESPACE env var, its simply a logistical support
- bumping infra chart now that release v1.3.0 exists
- Fixing multiple concurrent installations in a namespace