### PR TITLE
Fix Destination rule + double passing namespace

### DIFF
--- a/quickstart/examples/inference-scheduling/helmfile.yaml.gotmpl
+++ b/quickstart/examples/inference-scheduling/helmfile.yaml.gotmpl
@@ -16,9 +16,6 @@ environments:
 {{- $ns := .Namespace | default "llm-d-inference-scheduler" -}}
 {{- $rn := (env "RELEASE_NAME_POSTFIX") | default "inference-scheduling" -}}
 
-# set $ns as namespace for all releases
-namespace: {{ $ns }}
-
 repositories:
   - name: llm-d-modelservice
     url: https://llm-d-incubation.github.io/llm-d-modelservice/
@@ -38,7 +35,7 @@ releases:
       - {{ .Environment.Values | toYaml | nindent 8  }}
       - gateway:
           destinationRule:
-            host: {{ printf "gaie-inference-scheduling-epp.%s.svc.cluster.local" $ns | quote }}
+            host: {{ printf "gaie-%s-epp.%s.svc.cluster.local" $rn $ns | quote }}
 
   - name: {{ printf "gaie-%s" $rn | quote }}
     namespace: {{ $ns }}

--- a/quickstart/examples/pd-disaggregation/helmfile.yaml.gotmpl
+++ b/quickstart/examples/pd-disaggregation/helmfile.yaml.gotmpl
@@ -20,9 +20,6 @@ environments:
 {{- $ns := .Namespace | default "llm-d-pd" -}}
 {{- $rn := (env "RELEASE_NAME_POSTFIX") | default "pd" -}}
 
-# set $ns as namespace for all releases
-namespace: {{ $ns }}
-
 repositories:
   - name: llm-d-modelservice
     url: https://llm-d-incubation.github.io/llm-d-modelservice/
@@ -43,7 +40,7 @@ releases:
         {{ .Environment.Values.gateway | toYaml | nindent 10 }}
       - gateway:
           destinationRule:
-            host: {{ printf "gaie-pd-epp.%s.svc.cluster.local" $ns | quote }}
+            host: {{ printf "gaie-%s-epp.%s.svc.cluster.local" $ns | quote }}
 
   - name: {{ printf "gaie-%s" $rn | quote }}
     namespace: {{ $ns }}

--- a/quickstart/examples/precise-prefix-cache-aware/helmfile.yaml.gotmpl
+++ b/quickstart/examples/precise-prefix-cache-aware/helmfile.yaml.gotmpl
@@ -16,9 +16,6 @@ environments:
 {{- $ns := .Namespace | default "llm-d-precise" -}}
 {{- $rn := (env "RELEASE_NAME_POSTFIX") | default "kv-events" -}}
 
-# set $ns as namespace for all releases
-namespace: {{ $ns }}
-
 repositories:
   - name: llm-d-modelservice
     url: https://llm-d-incubation.github.io/llm-d-modelservice/
@@ -38,7 +35,7 @@ releases:
       - {{ .Environment.Values | toYaml | nindent 8  }}
       - gateway:
           destinationRule:
-            host: {{ printf "gaie-kv-events-epp.%s.svc.cluster.local" $ns | quote }}
+            host: {{ printf "gaie-%s-epp.%s.svc.cluster.local" $rn $ns | quote }}
 
   - name: {{ printf "gaie-%s" $rn | quote }}
     namespace: {{ $ns }}

--- a/quickstart/examples/sim/helmfile.yaml.gotmpl
+++ b/quickstart/examples/sim/helmfile.yaml.gotmpl
@@ -35,7 +35,7 @@ releases:
       - {{ .Environment.Values | toYaml | nindent 8  }}
       - gateway:
           destinationRule:
-            host: {{ printf "gaie-sim-epp.%s.svc.cluster.local" $ns | quote }}
+            host: {{ printf "gaie-%s-epp.%s.svc.cluster.local" $rn $ns | quote }}
 
   - name: {{ printf "gaie-%s" $rn | quote }}
     namespace: {{ $ns }}

--- a/quickstart/examples/wide-ep-lws/helmfile.yaml.gotmpl
+++ b/quickstart/examples/wide-ep-lws/helmfile.yaml.gotmpl
@@ -40,7 +40,7 @@ releases:
         {{ .Environment.Values.gateway | toYaml | nindent 10 }}
       - gateway:
           destinationRule:
-            host: {{ printf "ms-wide-ep-llm-d-modelservice-epp.%s.svc.cluster.local" $ns | quote }}
+            host: {{ printf "ms-%s-llm-d-modelservice-epp.%s.svc.cluster.local" $rn $ns | quote }}
 
   - name: {{ printf "ms-%s" $rn | quote }}
     namespace: {{ $ns }}


### PR DESCRIPTION
This produces a bug if you set namespace at both a top level and individual release level where it will explain that you cant pass the `--namespace` flag. Additionally the destinationRule host was not being templated properly based on the variable release name changes