### PR TITLE
Add a step to manually deploy HTTPRoute

### DIFF
--- a/.github/workflows/e2e-accelerator-test.yaml
+++ b/.github/workflows/e2e-accelerator-test.yaml
@@ -356,6 +356,17 @@ jobs:
             echo "---------------------------------------" >> ~/${{ matrix.deployment.helm_log_file }}
           EOF
 
+      - name: Deploy HTTPRoute
+        run: |
+          ssh -o StrictHostKeyChecking=no -i key.pem ubuntu@$INSTANCE_IP << EOF
+            set -euo pipefail
+            set -x
+            cd llm-d-infra/quickstart/${{ matrix.deployment.example_dir }}
+            echo "Deploying HTTPRoute..."
+            kubectl apply -f httproute.yaml | tee ~/${{ matrix.deployment.helm_log_file }}
+            echo "---------------------------------------" >> ~/${{ matrix.deployment.helm_log_file }}
+          EOF
+
       - name: Upload helm get all
         run: |
           ssh -o StrictHostKeyChecking=no -i key.pem ubuntu@$INSTANCE_IP << EOF

--- a/.github/workflows/e2e-pd-disaggregation-accelerator-test.yaml
+++ b/.github/workflows/e2e-pd-disaggregation-accelerator-test.yaml
@@ -428,6 +428,17 @@ jobs:
             echo "---------------------------------------" >> ~/pd-disaggregation-deployment.log
           EOF
 
+      - name: Deploy HTTPRoute
+        run: |
+          ssh -o StrictHostKeyChecking=no -i key.pem ubuntu@$INSTANCE_IP << EOF
+            set -euo pipefail
+            set -x
+            cd llm-d-infra/quickstart/${{ matrix.deployment.example_dir }}
+            echo "Deploying HTTPRoute..."
+            kubectl apply -f httproute.yaml | tee ~/${{ matrix.deployment.helm_log_file }}
+            echo "---------------------------------------" >> ~/${{ matrix.deployment.helm_log_file }}
+          EOF
+
       - name: Upload helm get all
         run: |
           ssh -o StrictHostKeyChecking=no -i key.pem ubuntu@$INSTANCE_IP << EOF

--- a/quickstart/examples/inference-scheduling/README.md
+++ b/quickstart/examples/inference-scheduling/README.md
@@ -48,13 +48,13 @@ You can also customize your gateway, for more information on how to do that see 
 
 Follow provider specific instructions for installing HTTPRoute.
 
-#### "kgateway" or "istio"
+#### Install for "kgateway" or "istio"
 
 ```bash
 kubectl apply -f httproute.yaml
 ```
 
-#### "gke"
+#### Install for "gke"
 
 ```bash
 kubectl apply -f httproute.gke.yaml
@@ -126,13 +126,13 @@ helm uninstall ms-inference-scheduling -n ${NAMESPACE}
 
 Follow provider specific instructions for deleting HTTPRoute.
 
-#### "kgateway" or "istio"
+#### Cleanup for "kgateway" or "istio" 
 
 ```bash
 kubectl delete -f httproute.yaml
 ```
 
-#### "gke"
+#### Cleanup for "gke"
 
 ```bash
 kubectl delete -f httproute.gke.yaml

--- a/quickstart/examples/inference-scheduling/README.md
+++ b/quickstart/examples/inference-scheduling/README.md
@@ -49,13 +49,15 @@ You can also customize your gateway, for more information on how to do that see 
 Follow provider specific instructions for installing HTTPRoute.
 
 === "kgateway" or "istio"
+
     ```bash
-    helmfile install -f httproute.yaml
+    kubectl apply -f httproute.yaml
     ```
 
 === "gke"
+
     ```
-    helmfile install -f httproute.gke.yaml
+    kubectl apply -f httproute.gke.yaml
     ```
 
 ## Verify the Installation

--- a/quickstart/examples/inference-scheduling/README.md
+++ b/quickstart/examples/inference-scheduling/README.md
@@ -122,6 +122,22 @@ helm uninstall ms-inference-scheduling -n ${NAMESPACE}
 
 **_NOTE:_** You do not need to specify your `environment` with the `-e <environment>` flag to `helmfile` for removing a installation of the quickstart, even if you use a non-default option. You do, however, have to set the `-n ${NAMESPACE}` otherwise it may not cleanup the releases in the proper namespace.
 
+### Cleanup HTTPRoute
+
+Follow provider specific instructions for deleting HTTPRoute.
+
+=== "kgateway" or "istio"
+
+    ```bash
+    kubectl delete -f httproute.yaml
+    ```
+
+=== "gke"
+
+    ```
+    kubectl delete -f httproute.gke.yaml
+    ```
+
 ## Customization
 
 For information on customizing an installation of a quickstart path and tips to build your own, see [our docs](../../docs/customizing-a-quickstart-inference-stack.md)

--- a/quickstart/examples/inference-scheduling/README.md
+++ b/quickstart/examples/inference-scheduling/README.md
@@ -126,7 +126,7 @@ helm uninstall ms-inference-scheduling -n ${NAMESPACE}
 
 Follow provider specific instructions for deleting HTTPRoute.
 
-#### Cleanup for "kgateway" or "istio" 
+#### Cleanup for "kgateway" or "istio"
 
 ```bash
 kubectl delete -f httproute.yaml

--- a/quickstart/examples/inference-scheduling/README.md
+++ b/quickstart/examples/inference-scheduling/README.md
@@ -48,17 +48,17 @@ You can also customize your gateway, for more information on how to do that see 
 
 Follow provider specific instructions for installing HTTPRoute.
 
-=== "kgateway" or "istio"
+#### "kgateway" or "istio"
 
-    ```bash
-    kubectl apply -f httproute.yaml
-    ```
+```bash
+kubectl apply -f httproute.yaml
+```
 
-=== "gke"
+#### "gke"
 
-    ```
-    kubectl apply -f httproute.gke.yaml
-    ```
+```bash
+kubectl apply -f httproute.gke.yaml
+```
 
 ## Verify the Installation
 
@@ -126,17 +126,17 @@ helm uninstall ms-inference-scheduling -n ${NAMESPACE}
 
 Follow provider specific instructions for deleting HTTPRoute.
 
-=== "kgateway" or "istio"
+#### "kgateway" or "istio"
 
-    ```bash
-    kubectl delete -f httproute.yaml
-    ```
+```bash
+kubectl delete -f httproute.yaml
+```
 
-=== "gke"
+#### "gke"
 
-    ```
-    kubectl delete -f httproute.gke.yaml
-    ```
+```bash
+kubectl delete -f httproute.gke.yaml
+```
 
 ## Customization
 

--- a/quickstart/examples/inference-scheduling/README.md
+++ b/quickstart/examples/inference-scheduling/README.md
@@ -44,6 +44,20 @@ To see what gateway options are supported refer to our [gateway control plane do
 
 You can also customize your gateway, for more information on how to do that see our [gateway customization docs](../../docs/customizing-your-gateway.md).
 
+### Install HTTPRoute
+
+Follow provider specific instructions for installing HTTPRoute.
+
+=== "kgateway" or "istio"
+    ```bash
+    helmfile install -f httproute.yaml
+    ```
+
+=== "gke"
+    ```
+    helmfile install -f httproute.gke.yaml
+    ```
+
 ## Verify the Installation
 
 - Firstly, you should be able to list all helm releases to view the 3 charts got installed into your chosen namespace:

--- a/quickstart/examples/inference-scheduling/helmfile.yaml.gotmpl
+++ b/quickstart/examples/inference-scheduling/helmfile.yaml.gotmpl
@@ -35,7 +35,8 @@ releases:
       type: infrastructure
       kind: inference-stack
     values:
-      - {{ .Environment.Values | toYaml | nindent 8  }}
+      - gateway:
+        {{ .Environment.Values.gateway | toYaml | nindent 10 }}
       - gateway:
           destinationRule:
             host: {{ printf "gaie-inference-scheduling-epp.%s.svc.cluster.local" $ns | quote }}
@@ -50,7 +51,8 @@ releases:
     values:
       - gaie-inference-scheduling/values.yaml
     {{- if eq .Environment.Name "gke" }}
-      - provider: {{ .Environment.Values.provider }}
+      - provider:
+          name: {{ .Environment.Values.provider.name }}
     {{- end }}
     labels:
       kind: inference-stack

--- a/quickstart/examples/inference-scheduling/httproute.gke.yaml
+++ b/quickstart/examples/inference-scheduling/httproute.gke.yaml
@@ -1,0 +1,21 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: ms-inference-scheduling-llm-d-modelservice
+  namespace: llm-d-inference-scheduler
+spec:
+  parentRefs:
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    name: infra-inference-scheduling-inference-gateway
+  rules:
+    - backendRefs:
+      - group: inference.networking.x-k8s.io
+        kind: InferencePool
+        name: gaie-inference-scheduling
+        port: 8000
+        weight: 1
+      matches:
+      - path:
+          type: PathPrefix
+          value: /

--- a/quickstart/examples/inference-scheduling/httproute.gke.yaml
+++ b/quickstart/examples/inference-scheduling/httproute.gke.yaml
@@ -1,7 +1,7 @@
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
-  name: ms-inference-scheduling-llm-d-modelservice
+  name: llm-d-inference-scheduling
   namespace: llm-d-inference-scheduler
 spec:
   parentRefs:

--- a/quickstart/examples/inference-scheduling/httproute.yaml
+++ b/quickstart/examples/inference-scheduling/httproute.yaml
@@ -1,0 +1,24 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: ms-inference-scheduling-llm-d-modelservice
+  namespace: llm-d-inference-scheduler
+spec:
+  parentRefs:
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    name: infra-inference-scheduling-inference-gateway
+  rules:
+    - backendRefs:
+      - group: inference.networking.x-k8s.io
+        kind: InferencePool
+        name: gaie-inference-scheduling
+        port: 8000
+        weight: 1
+      timeouts:
+        backendRequest: 0s
+        request: 0s
+      matches:
+      - path:
+          type: PathPrefix
+          value: /

--- a/quickstart/examples/inference-scheduling/httproute.yaml
+++ b/quickstart/examples/inference-scheduling/httproute.yaml
@@ -1,7 +1,7 @@
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
-  name: ms-inference-scheduling-llm-d-modelservice
+  name: llm-d-inference-scheduling
   namespace: llm-d-inference-scheduler
 spec:
   parentRefs:

--- a/quickstart/examples/inference-scheduling/ms-inference-scheduling/values.yaml
+++ b/quickstart/examples/inference-scheduling/ms-inference-scheduling/values.yaml
@@ -27,7 +27,7 @@ routing:
     # name: gaie-inference-scheduling # set in helmfile
 
   httpRoute:
-    create: true
+    create: false
 
   epp:
     create: false

--- a/quickstart/examples/pd-disaggregation/README.md
+++ b/quickstart/examples/pd-disaggregation/README.md
@@ -72,6 +72,20 @@ You can also customize your gateway, for more information on how to do that see 
 
 While this example out of the box requires Infiniband RDMA, GKE does not support this. Therefore we patch out these values in [the helmfile](./helmfile.yaml.gotmpl#L73-80).
 
+### Install HTTPRoute
+
+Follow provider specific instructions for installing HTTPRoute.
+
+=== "kgateway" or "istio"
+    ```bash
+    helmfile install -f httproute.yaml
+    ```
+
+=== "gke"
+    ```
+    helmfile install -f httproute.gke.yaml
+    ```
+
 ## Verify the Installation
 
 - Firstly, you should be able to list all helm releases to view the 3 charts got installed into your chosen namespace:

--- a/quickstart/examples/pd-disaggregation/README.md
+++ b/quickstart/examples/pd-disaggregation/README.md
@@ -77,11 +77,13 @@ While this example out of the box requires Infiniband RDMA, GKE does not support
 Follow provider specific instructions for installing HTTPRoute.
 
 === "kgateway" or "istio"
+
     ```bash
     helmfile install -f httproute.yaml
     ```
 
 === "gke"
+
     ```
     helmfile install -f httproute.gke.yaml
     ```

--- a/quickstart/examples/pd-disaggregation/README.md
+++ b/quickstart/examples/pd-disaggregation/README.md
@@ -79,13 +79,13 @@ Follow provider specific instructions for installing HTTPRoute.
 === "kgateway" or "istio"
 
     ```bash
-    helmfile install -f httproute.yaml
+    kubectl apply -f httproute.yaml
     ```
 
 === "gke"
 
     ```
-    helmfile install -f httproute.gke.yaml
+    kubectl apply -f httproute.gke.yaml
     ```
 
 ## Verify the Installation
@@ -154,6 +154,22 @@ helm uninstall infra-pd -n ${NAMESPACE}
 **_NOTE:_** If you set the `$RELEASE_NAME_POSTFIX` environment variable, your release names will be different from the command above: `infra-$RELEASE_NAME_POSTFIX`, `gaie-$RELEASE_NAME_POSTFIX` and `ms-$RELEASE_NAME_POSTFIX`.
 
 **_NOTE:_** You do not need to specify your `environment` with the `-e <environment>` flag to `helmfile` for removing a installation of the quickstart, even if you use a non-default option. You do, however, have to set the `-n ${NAMESPACE}` otherwise it may not cleanup the releases in the proper namespace.
+
+### Cleanup HTTPRoute
+
+Follow provider specific instructions for deleting HTTPRoute.
+
+=== "kgateway" or "istio"
+
+    ```bash
+    kubectl delete -f httproute.yaml
+    ```
+
+=== "gke"
+
+    ```
+    kubectl delete -f httproute.gke.yaml
+    ```
 
 ## Customization
 

--- a/quickstart/examples/pd-disaggregation/README.md
+++ b/quickstart/examples/pd-disaggregation/README.md
@@ -76,13 +76,13 @@ While this example out of the box requires Infiniband RDMA, GKE does not support
 
 Follow provider specific instructions for installing HTTPRoute.
 
-#### "kgateway" or "istio"
+#### Install for "kgateway" or "istio"
 
 ```bash
 kubectl apply -f httproute.yaml
 ```
 
-#### "gke"
+#### Install for "gke"
 
 ```bash
 kubectl apply -f httproute.gke.yaml
@@ -159,13 +159,13 @@ helm uninstall infra-pd -n ${NAMESPACE}
 
 Follow provider specific instructions for deleting HTTPRoute.
 
-#### "kgateway" or "istio"
+#### Cleanup for "kgateway" or "istio"
 
 ```bash
 kubectl delete -f httproute.yaml
 ```
 
-#### "gke"
+#### Cleanup for "gke"
 
 ```bash
 kubectl delete -f httproute.gke.yaml

--- a/quickstart/examples/pd-disaggregation/README.md
+++ b/quickstart/examples/pd-disaggregation/README.md
@@ -76,17 +76,17 @@ While this example out of the box requires Infiniband RDMA, GKE does not support
 
 Follow provider specific instructions for installing HTTPRoute.
 
-=== "kgateway" or "istio"
+#### "kgateway" or "istio"
 
-    ```bash
-    kubectl apply -f httproute.yaml
-    ```
+```bash
+kubectl apply -f httproute.yaml
+```
 
-=== "gke"
+#### "gke"
 
-    ```
-    kubectl apply -f httproute.gke.yaml
-    ```
+```bash
+kubectl apply -f httproute.gke.yaml
+```
 
 ## Verify the Installation
 
@@ -159,17 +159,17 @@ helm uninstall infra-pd -n ${NAMESPACE}
 
 Follow provider specific instructions for deleting HTTPRoute.
 
-=== "kgateway" or "istio"
+#### "kgateway" or "istio"
 
-    ```bash
-    kubectl delete -f httproute.yaml
-    ```
+```bash
+kubectl delete -f httproute.yaml
+```
 
-=== "gke"
+#### "gke"
 
-    ```
-    kubectl delete -f httproute.gke.yaml
-    ```
+```bash
+kubectl delete -f httproute.gke.yaml
+```
 
 ## Customization
 

--- a/quickstart/examples/pd-disaggregation/helmfile.yaml.gotmpl
+++ b/quickstart/examples/pd-disaggregation/helmfile.yaml.gotmpl
@@ -55,7 +55,8 @@ releases:
     values:
       - gaie-pd/values.yaml
     {{- if eq .Environment.Name "gke" }}
-      - provider: {{ .Environment.Values.provider }}
+      - provider:
+          name: {{ .Environment.Values.provider.name }}
     {{- end }}
     {{- if or (eq .Environment.Name "istioBench") (eq .Environment.Name "default") }}
       - inferenceExtension:

--- a/quickstart/examples/pd-disaggregation/httproute.gke.yaml
+++ b/quickstart/examples/pd-disaggregation/httproute.gke.yaml
@@ -1,7 +1,7 @@
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
-  name: ms-inference-scheduling-llm-d-modelservice
+  name: llm-d-pd-disaggregation
   namespace: llm-d-inference-scheduler
 spec:
   parentRefs:

--- a/quickstart/examples/pd-disaggregation/httproute.gke.yaml
+++ b/quickstart/examples/pd-disaggregation/httproute.gke.yaml
@@ -1,0 +1,21 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: ms-inference-scheduling-llm-d-modelservice
+  namespace: llm-d-inference-scheduler
+spec:
+  parentRefs:
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    name: infra-inference-scheduling-inference-gateway
+  rules:
+    - backendRefs:
+      - group: inference.networking.x-k8s.io
+        kind: InferencePool
+        name: gaie-inference-scheduling
+        port: 8000
+        weight: 1
+      matches:
+      - path:
+          type: PathPrefix
+          value: /

--- a/quickstart/examples/pd-disaggregation/httproute.gke.yaml
+++ b/quickstart/examples/pd-disaggregation/httproute.gke.yaml
@@ -2,17 +2,17 @@ apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: llm-d-pd-disaggregation
-  namespace: llm-d-inference-scheduler
+  namespace: llm-d-pd
 spec:
   parentRefs:
   - group: gateway.networking.k8s.io
     kind: Gateway
-    name: infra-inference-scheduling-inference-gateway
+    name: infra-pd-inference-gateway
   rules:
     - backendRefs:
       - group: inference.networking.x-k8s.io
         kind: InferencePool
-        name: gaie-inference-scheduling
+        name: gaie-pd
         port: 8000
         weight: 1
       matches:

--- a/quickstart/examples/pd-disaggregation/httproute.yaml
+++ b/quickstart/examples/pd-disaggregation/httproute.yaml
@@ -1,0 +1,24 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: ms-inference-scheduling-llm-d-modelservice
+  namespace: llm-d-inference-scheduler
+spec:
+  parentRefs:
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    name: infra-inference-scheduling-inference-gateway
+  rules:
+    - backendRefs:
+      - group: inference.networking.x-k8s.io
+        kind: InferencePool
+        name: gaie-inference-scheduling
+        port: 8000
+        weight: 1
+      timeouts:
+        backendRequest: 0s
+        request: 0s
+      matches:
+      - path:
+          type: PathPrefix
+          value: /

--- a/quickstart/examples/pd-disaggregation/httproute.yaml
+++ b/quickstart/examples/pd-disaggregation/httproute.yaml
@@ -1,18 +1,18 @@
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
-  name: ms-inference-scheduling-llm-d-modelservice
-  namespace: llm-d-inference-scheduler
+  name: llm-d-pd-disaggregation
+  namespace: llm-d-pd
 spec:
   parentRefs:
   - group: gateway.networking.k8s.io
     kind: Gateway
-    name: infra-inference-scheduling-inference-gateway
+    name: infra-pd-inference-gateway
   rules:
     - backendRefs:
       - group: inference.networking.x-k8s.io
         kind: InferencePool
-        name: gaie-inference-scheduling
+        name: gaie-pd
         port: 8000
         weight: 1
       timeouts:

--- a/quickstart/examples/pd-disaggregation/ms-pd/values.yaml
+++ b/quickstart/examples/pd-disaggregation/ms-pd/values.yaml
@@ -28,7 +28,7 @@ routing:
     # name: gaie-pd # set in helmfile
 
   httpRoute:
-    create: true
+    create: false
 
   epp:
     create: false


### PR DESCRIPTION
I am limiting the scope to only inference scheduling and pd-disaggregation examples for now. 