### PR TITLE
Use a different notification action

### DIFF
--- a/.github/workflows/e2e-inference-scheduling-gke.yaml
+++ b/.github/workflows/e2e-inference-scheduling-gke.yaml
@@ -134,7 +134,7 @@ jobs:
             --for=condition=Ready \
             --all \
             -n "${NAMESPACE}" \
-            --timeout=10m
+            --timeout=15m
           sleep ${{ matrix.accelerator.pod_readiness_sleep_seconds }} # TODO: remove this once examples have readiness probes
           echo "✅ All pods are ready."
           kubectl get pods -n "${NAMESPACE}"

--- a/.github/workflows/e2e-inference-scheduling-gke.yaml
+++ b/.github/workflows/e2e-inference-scheduling-gke.yaml
@@ -201,11 +201,11 @@ jobs:
 
       - name: Send Google Chat notification on failure
         if: failure()
-        uses: Co-qn/google-chat-notification@3691ccf4763537d6e544bc6cdcccc1965799d056
+        uses: SimonScholz/google-chat-action@3b3519e5102dba8aa5046fd711c4b553586409bb
         with:
-          url: ${{ secrets.GOOGLE_CHAT_WEBHOOK }}
-          name: '${{ github.workflow }} - ${{ matrix.accelerator.name }}'
-          status: ${{ job.status }}
+          webhookUrl: ${{ secrets.GOOGLE_CHAT_WEBHOOK }}
+          jobStatus: ${{ job.status }}
+          title: '${{ github.workflow }} - ${{ matrix.accelerator.name }}'
 
       - name: Cleanup deployment
         if: always()

--- a/.github/workflows/e2e-pd-disaggregation-gke.yaml
+++ b/.github/workflows/e2e-pd-disaggregation-gke.yaml
@@ -159,7 +159,7 @@ jobs:
             --for=condition=Ready \
             --all \
             -n "${NAMESPACE}" \
-            --timeout=10m
+            --timeout=15m
           sleep 480 # Allow extra time for model loading in PD setup
           echo "✅ All pods are ready."
           kubectl get pods -n "${NAMESPACE}"

--- a/.github/workflows/e2e-pd-disaggregation-gke.yaml
+++ b/.github/workflows/e2e-pd-disaggregation-gke.yaml
@@ -246,11 +246,11 @@ jobs:
 
       - name: Send Google Chat notification on failure
         if: failure()
-        uses: Co-qn/google-chat-notification@3691ccf4763537d6e544bc6cdcccc1965799d056
+        uses: SimonScholz/google-chat-action@3b3519e5102dba8aa5046fd711c4b553586409bb
         with:
-          url: ${{ secrets.GOOGLE_CHAT_WEBHOOK }}
-          name: ${{ github.workflow }}
-          status: ${{ job.status }}
+          webhookUrl: ${{ secrets.GOOGLE_CHAT_WEBHOOK }}
+          jobStatus: ${{ job.status }}
+          title: ${{ github.workflow }}
 
       - name: Cleanup deployment
         if: always()


### PR DESCRIPTION
The previous google chat notification does not have direct link to the action run, it's showing all actions running at a certain commit hash (which is hard for debugging). Switching to this new action which gives a direct link to the failed action.