### PR TITLE
Disable GKE nightly test for llm-d-infra

### DIFF
--- a/.github/workflows/e2e-inference-scheduling-gke.yaml
+++ b/.github/workflows/e2e-inference-scheduling-gke.yaml
@@ -4,8 +4,8 @@ on:
   # Runs with a PR comment /run-gke-inference-scheduling
   issue_comment:
     types: [created]
-  schedule: # TODO: enable once validated functional
-    - cron: '0 8 * * *'  # 1AM PST (08:00 UTC)
+  #schedule: # TODO: enable once validated functional
+  #  - cron: '0 8 * * *'  # 1AM PST (08:00 UTC)
   workflow_dispatch:
     inputs:
       pr_or_branch:

--- a/.github/workflows/e2e-pd-disaggregation-gke.yaml
+++ b/.github/workflows/e2e-pd-disaggregation-gke.yaml
@@ -4,8 +4,8 @@ on:
   # Runs with a PR comment /run-gke-pd-disaggregation
   issue_comment:
     types: [created]
-  schedule: # TODO: enable once validated functional
-    - cron: '0 9 * * *'  # 2AM PST (09:00 UTC)
+  #schedule: # TODO: enable once validated functional
+  #  - cron: '0 9 * * *'  # 2AM PST (09:00 UTC)
   workflow_dispatch:
     inputs:
       pr_or_branch:


### PR DESCRIPTION
Test has been moved to the llm-d/llm-d repo, disabling the deprecated tests here.