### PR TITLE
update Gateway TLS field to certificateRefs to fix validation error

### DIFF
--- a/charts/llm-d-infra/templates/gateway-infrastructure/gateway.yaml
+++ b/charts/llm-d-infra/templates/gateway-infrastructure/gateway.yaml
@@ -42,10 +42,14 @@ spec:
       hostname: {{ $l.tls.hostname | quote }}
       tls:
         mode: {{ $l.tls.mode | quote }}
-        {{- with $l.tls.certificateRef }}
-        certificateRef:
-          name: {{ .name | quote }}
-          namespace: {{ .namespace | quote }}
+        {{- if $l.tls.certificateRefs }}
+        certificateRefs:
+          {{- range $l.tls.certificateRefs }}
+          - name: {{ .name | quote }}
+            {{- if .namespace }}
+            namespace: {{ .namespace | quote }}
+            {{- end }}
+          {{- end }}
         {{- end }}
       {{- end }}
   {{- end}}

--- a/charts/llm-d-infra/values.schema.json
+++ b/charts/llm-d-infra/values.schema.json
@@ -253,24 +253,28 @@
                             "tls": {
                                 "description": "TLS configuration for the Listener. Required when protocol is HTTPS or TLS.",
                                 "properties": {
-                                    "certificateRef": {
-                                        "description": "Reference to a Kubernetes Secret containing the TLS certificate.",
-                                        "properties": {
-                                            "name": {
-                                                "description": "Name of the Secret containing the TLS certificate.",
-                                                "required": [],
-                                                "type": "string"
+                                    "certificateRefs": {
+                                        "description": "References to Kubernetes Secrets containing TLS certificates.",
+                                        "items": {
+                                            "properties": {
+                                                "name": {
+                                                    "description": "Name of the Secret containing the TLS certificate.",
+                                                    "required": [],
+                                                    "type": "string"
+                                                },
+                                                "namespace": {
+                                                    "description": "Namespace of the Secret. If omitted, defaults to the Gateway's namespace.",
+                                                    "required": [],
+                                                    "type": "string"
+                                                }
                                             },
-                                            "namespace": {
-                                                "description": "Namespace of the Secret. If omitted, defaults to the Gateway's namespace.",
-                                                "required": [],
-                                                "type": "string"
-                                            }
+                                            "required": [
+                                                "name"
+                                            ],
+                                            "type": "object"
                                         },
-                                        "required": [
-                                            "name"
-                                        ],
-                                        "type": "object"
+                                        "required": [],
+                                        "type": "array"
                                     },
                                     "hostname": {
                                         "description": "Hostname to match for TLS SNI. Required for TLS termination.",
@@ -310,8 +314,13 @@
                 },
                 "service": {
                     "additionalProperties": false,
-                    "description": " type: object additionalProperties: false required: [type] properties:   type:     type: string     description: >       Gateway's service type. Ingress is only available if the service type       is set to LoadBalancer. Accepted values: [\"LoadBalancer\",\"ClusterIP\",\"NodePort\"].     enum: [LoadBalancer, ClusterIP, NodePort]     default: ClusterIP   ports:     type: array     description: >       Optional. List of service ports. If provided, each item must include \"port\".     items:       type: object       additionalProperties: true       required: [port]       properties:         port:           description: >             Port is the network port. Multiple listeners may use the same port             (subject to compatibility rules).           type: integer           minimum: 1           maximum: 65535         nodePort:           type: integer           minimum: 30000           maximum: 32767 @schema",
+                    "description": " type: object additionalProperties: false required: [type] properties:   type:     type: string     description: >       Gateway's service type. Ingress is only available if the service type       is set to LoadBalancer. Accepted values: [\"LoadBalancer\",\"ClusterIP\",\"NodePort\"].     enum: [LoadBalancer, ClusterIP, NodePort]     default: ClusterIP   ports:     type: array     description: >       Optional. List of service ports. If provided, each item must include \"port\".     items:       type: object       additionalProperties: true       required: [port]       properties:         port:           description: >             Port is the network port. Multiple listeners may use the same port             (subject to compatibility rules).           type: integer           minimum: 1           maximum: 65535         nodePort:           type: integer           minimum: 30000           maximum: 32767   loadBalancerClass:     type: string     description: >       Optional. LoadBalancerClass is the class of the load balancer to use.       Ref: https://kubernetes.io/docs/concepts/services-networking/service/#load-balancer-class @schema",
                     "properties": {
+                        "loadBalancerClass": {
+                            "description": "Optional. LoadBalancerClass is the class of the load balancer to use. Ref: https://kubernetes.io/docs/concepts/services-networking/service/#load-balancer-class",
+                            "required": [],
+                            "type": "string"
+                        },
                         "ports": {
                             "description": "Optional. List of service ports. If provided, each item must include \"port\".\n",
                             "items": {

--- a/charts/llm-d-infra/values.schema.tmpl.json
+++ b/charts/llm-d-infra/values.schema.tmpl.json
@@ -199,24 +199,28 @@
               "tls": {
                 "description": "TLS configuration for the Listener. Required when protocol is HTTPS or TLS.",
                 "properties": {
-                  "certificateRef": {
-                    "description": "Reference to a Kubernetes Secret containing the TLS certificate.",
-                    "properties": {
-                      "name": {
-                        "description": "Name of the Secret containing the TLS certificate.",
-                        "required": [],
-                        "type": "string"
+                  "certificateRefs": {
+                    "description": "References to Kubernetes Secrets containing TLS certificates.",
+                    "items": {
+                      "properties": {
+                        "name": {
+                          "description": "Name of the Secret containing the TLS certificate.",
+                          "required": [],
+                          "type": "string"
+                        },
+                        "namespace": {
+                          "description": "Namespace of the Secret. If omitted, defaults to the Gateway's namespace.",
+                          "required": [],
+                          "type": "string"
+                        }
                       },
-                      "namespace": {
-                        "description": "Namespace of the Secret. If omitted, defaults to the Gateway's namespace.",
-                        "required": [],
-                        "type": "string"
-                      }
+                      "required": [
+                        "name"
+                      ],
+                      "type": "object"
                     },
-                    "required": [
-                      "name"
-                    ],
-                    "type": "object"
+                    "required": [],
+                    "type": "array"
                   },
                   "hostname": {
                     "description": "Hostname to match for TLS SNI. Required for TLS termination.",
@@ -256,8 +260,13 @@
         },
         "service": {
           "additionalProperties": false,
-          "description": " type: object additionalProperties: false required: [type] properties:   type:     type: string     description: \u003e       Gateway's service type. Ingress is only available if the service type       is set to LoadBalancer. Accepted values: [\"LoadBalancer\",\"ClusterIP\",\"NodePort\"].     enum: [LoadBalancer, ClusterIP, NodePort]     default: ClusterIP   ports:     type: array     description: \u003e       Optional. List of service ports. If provided, each item must include \"port\".     items:       type: object       additionalProperties: true       required: [port]       properties:         port:           description: \u003e             Port is the network port. Multiple listeners may use the same port             (subject to compatibility rules).           type: integer           minimum: 1           maximum: 65535         nodePort:           type: integer           minimum: 30000           maximum: 32767 @schema",
+          "description": " type: object additionalProperties: false required: [type] properties:   type:     type: string     description: \u003e       Gateway's service type. Ingress is only available if the service type       is set to LoadBalancer. Accepted values: [\"LoadBalancer\",\"ClusterIP\",\"NodePort\"].     enum: [LoadBalancer, ClusterIP, NodePort]     default: ClusterIP   ports:     type: array     description: \u003e       Optional. List of service ports. If provided, each item must include \"port\".     items:       type: object       additionalProperties: true       required: [port]       properties:         port:           description: \u003e             Port is the network port. Multiple listeners may use the same port             (subject to compatibility rules).           type: integer           minimum: 1           maximum: 65535         nodePort:           type: integer           minimum: 30000           maximum: 32767   loadBalancerClass:     type: string     description: \u003e       Optional. LoadBalancerClass is the class of the load balancer to use.       Ref: https://kubernetes.io/docs/concepts/services-networking/service/#load-balancer-class @schema",
           "properties": {
+            "loadBalancerClass": {
+              "description": "Optional. LoadBalancerClass is the class of the load balancer to use. Ref: https://kubernetes.io/docs/concepts/services-networking/service/#load-balancer-class",
+              "required": [],
+              "type": "string"
+            },
             "ports": {
               "description": "Optional. List of service ports. If provided, each item must include \"port\".\n",
               "items": {

--- a/charts/llm-d-infra/values.yaml
+++ b/charts/llm-d-infra/values.yaml
@@ -161,17 +161,19 @@ gateway:
   #           type: string
   #           description: TLS mode. Typically "Terminate" for TLS termination at the gateway.
   #           enum: [Terminate, Passthrough]
-  #         certificateRef:
-  #           type: object
-  #           description: Reference to a Kubernetes Secret containing the TLS certificate.
-  #           required: [name]
-  #           properties:
-  #             name:
-  #               type: string
-  #               description: Name of the Secret containing the TLS certificate.
-  #             namespace:
-  #               type: string
-  #               description: Namespace of the Secret. If omitted, defaults to the Gateway's namespace.
+  #         certificateRefs:
+  #           type: array
+  #           description: References to Kubernetes Secrets containing TLS certificates.
+  #           items:
+  #             type: object
+  #             required: [name]
+  #             properties:
+  #               name:
+  #                 type: string
+  #                 description: Name of the Secret containing the TLS certificate.
+  #               namespace:
+  #                 type: string
+  #                 description: Namespace of the Secret. If omitted, defaults to the Gateway's namespace.
   # @schema
   # -- Set of listeners exposed via the Gateway, also propagated to the Ingress if enabled
   listeners:
@@ -185,9 +187,9 @@ gateway:
       # tls:
       #   hostname: "api.example.com"
       #   mode: "Terminate"  # or "Passthrough"
-      #   certificateRef:
-      #     name: "my-tls-cert"
-      #     namespace: "default"
+      #   certificateRefs:
+      #     - name: "my-tls-cert"
+      #       namespace: "default"
 
   # @schema
   # type: object
@@ -221,7 +223,7 @@ gateway:
   #           type: integer
   #           minimum: 30000
   #           maximum: 32767
-  #   loadBalancerClass: 
+  #   loadBalancerClass:
   #     type: string
   #     description: >
   #       Optional. LoadBalancerClass is the class of the load balancer to use.


### PR DESCRIPTION
### Description
This PR updates the `gateway.yaml` template to use `certificateRefs` (an array) instead of `certificateRef` (a single object) in the TLS configuration section. This change aligns the chart with the Kubernetes Gateway API specification.

### Related Issue
#242

### Changes Made
- Updated `charts/llm-d-infra/templates/gateway-infrastructure/gateway.yaml` to iterate over `certificateRefs`.
- Updated `charts/llm-d-infra/values.yaml` to reflect the new array structure in examples and schema annotations.
- Regenerated schema files (`values.schema.json`) via pre-commit hooks.