### PR TITLE
Fix: Link to Development Guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ For detailed configuration options, see the [Helm chart documentation](charts/ll
    - Helm chart improvements
    - Operational tooling enhancements
    - Infrastructure configuration updates
-3. **Development Setup:** See [development documentation](quickstart/docs/development.md)
+3. **Development Setup:** See [development documentation](docs/development.md)
 
 ### Code Owners
 


### PR DESCRIPTION
The link to Development Setup was pointing to a nonexistent path. 

Testing: Not required - Only a documentation fix