### PR TITLE
Remove link that moved to llm-d main repo and update dev guide link

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,7 @@ For detailed configuration options, see the [Helm chart documentation](charts/ll
 **This repository contains:**
 
 - [Helm Chart Documentation](charts/llm-d-infra/README.md)
-- [Development Guide](quickstart/docs/development.md)
-- [Interactive Testing Tools](helpers/interactive-pod/README.md)
+- [Development Guide](docs/development.md)
 
 ## Contributing
 


### PR DESCRIPTION
The "Interactive Testing Tools" looks like they moved to the main llm-d repo so no longer in this repository.  Also I updated the link for the dev guide. 