### PR TITLE
add configurable gateway replicas

### DIFF
--- a/charts/llm-d-infra/README.md
+++ b/charts/llm-d-infra/README.md
@@ -114,6 +114,7 @@ Kubernetes: `>= 1.28.0-0`
 | gateway.enabled | Deploy resources related to Gateway | bool | `true` |
 | gateway.fullnameOverride | String to fully override gateway.fullname | string | `""` |
 | gateway.gatewayClassName | Gateway class that determines the backend used Currently supported values: "kgateway", "istio", or "gke-l7-regional-external-managed" | string | `"istio"` |
+| gateway.gatewayParameters.replicas | Number of replicas for the gateway | int | `1` |
 | gateway.gatewayParameters.resources | Resource requests/limits <br /> Ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-requests-and-limits-of-pod-and-container | object | `{"limits":{"cpu":"2","memory":"1Gi"},"requests":{"cpu":"100m","memory":"128Mi"}}` |
 | gateway.labels | Additional labels provided to the Gateway resource | object | `{}` |
 | gateway.listeners | Set of listeners exposed via the Gateway, also propagated to the Ingress if enabled | list | `[{"allowedRoutes":{"namespaces":{"from":"All"}},"name":"default","path":"/","port":80,"protocol":"HTTP"}]` |

--- a/charts/llm-d-infra/templates/gateway-infrastructure/configmap.yaml
+++ b/charts/llm-d-infra/templates/gateway-infrastructure/configmap.yaml
@@ -19,6 +19,7 @@ metadata:
 data:
   deployment: |
     spec:
+      replicas: {{ .Values.gateway.gatewayParameters.replicas }}
       template:
         spec:
           containers:

--- a/charts/llm-d-infra/templates/gateway-infrastructure/gatewayparameters.yaml
+++ b/charts/llm-d-infra/templates/gateway-infrastructure/gatewayparameters.yaml
@@ -18,6 +18,8 @@ metadata:
     {{- end }}
 spec:
   kube:
+    deployment:
+      replicas: {{ .Values.gateway.gatewayParameters.replicas }}
     envoyContainer:
       securityContext:
         allowPrivilegeEscalation: false

--- a/charts/llm-d-infra/values.schema.json
+++ b/charts/llm-d-infra/values.schema.json
@@ -179,6 +179,12 @@
                             "required": [],
                             "title": "logLevel"
                         },
+                        "replicas": {
+                            "default": "1",
+                            "description": "Number of replicas for the gateway",
+                            "required": [],
+                            "title": "replicas"
+                        },
                         "resources": {
                             "description": "ResourceRequirements describes the compute resource requirements.",
                             "properties": {

--- a/charts/llm-d-infra/values.schema.tmpl.json
+++ b/charts/llm-d-infra/values.schema.tmpl.json
@@ -179,6 +179,12 @@
               "required": [],
               "title": "logLevel"
             },
+            "replicas": {
+              "default": "1",
+              "description": "Number of replicas for the gateway",
+              "required": [],
+              "title": "replicas"
+            },
             "resources": {
               "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master/_definitions.json#/definitions/io.k8s.api.core.v1.ResourceRequirements",
               "description": "Resource requests/limits \u003cbr /\u003e Ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-requests-and-limits-of-pod-and-container",

--- a/charts/llm-d-infra/values.yaml
+++ b/charts/llm-d-infra/values.yaml
@@ -85,6 +85,9 @@ gateway:
     # @schema
     logLevel: info
 
+    # -- Number of replicas for the gateway
+    replicas: 1
+
     # @schema
     # $ref: https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master/_definitions.json#/definitions/io.k8s.api.core.v1.ResourceRequirements
     # @schema


### PR DESCRIPTION
use `gateway.gatewayParameters.replicas` to configure gateway replicas.

in production env, gateway replica count must be configurable, but this is not supported today.
