### PR TITLE
feat(gateway): Add nodeSelector support for gateway pod

### DIFF
--- a/charts/llm-d-infra/README.md
+++ b/charts/llm-d-infra/README.md
@@ -122,6 +122,7 @@ Kubernetes: `>= 1.28.0-0`
 | gateway.gatewayParameters.istio | Istio-specific parameters rendered into the gateway ConfigMap when gateway.provider resolves to "istio" | object | `{"accessLogging":true}` |
 | gateway.gatewayParameters.istio.accessLogging | For istio to include access logging or not | bool | `true` |
 | gateway.gatewayParameters.logLevel | Log level for provider-managed gateway data plane components | string | `"warn"` |
+| gateway.gatewayParameters.nodeSelector | Optional node selector for the gateway pod | object | `{}` |
 | gateway.gatewayParameters.resources | Resource requests/limits <br /> Ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-requests-and-limits-of-pod-and-container | object | `{"limits":{"cpu":"2","memory":"1Gi"},"requests":{"cpu":"100m","memory":"128Mi"}}` |
 | gateway.labels | Additional labels provided to the Gateway resource | object | `{}` |
 | gateway.listeners | Set of listeners exposed via the Gateway, also propagated to the Ingress if enabled | list | `[{"allowedRoutes":{"namespaces":{"from":"All"}},"name":"default","port":80,"protocol":"HTTP"}]` |

--- a/charts/llm-d-infra/templates/gateway-infrastructure/agentgatewayparameters.yaml
+++ b/charts/llm-d-infra/templates/gateway-infrastructure/agentgatewayparameters.yaml
@@ -35,6 +35,13 @@ spec:
   {{- if .Values.gateway.gatewayParameters.agentgateway.istio }}
   istio: {{ .Values.gateway.gatewayParameters.agentgateway.istio | toYaml | nindent 4 }}
   {{- end }}
+  {{- if and .Values.gateway.gatewayParameters.nodeSelector (eq (include "gateway.provider" .) "agentgateway") }}
+  deployment:
+    spec:
+      template:
+        spec:
+          nodeSelector: {{ .Values.gateway.gatewayParameters.nodeSelector | toYaml | nindent 12 }}
+  {{- end }}
   service:
     metadata:
       labels:

--- a/charts/llm-d-infra/templates/gateway-infrastructure/configmap.yaml
+++ b/charts/llm-d-infra/templates/gateway-infrastructure/configmap.yaml
@@ -40,6 +40,9 @@ data:
             {{- if .Values.gateway.gatewayParameters.resources }}
             resources: {{ .Values.gateway.gatewayParameters.resources | toYaml | nindent 14 }}
             {{- end}}
+          {{- if .Values.gateway.gatewayParameters.nodeSelector }}
+          nodeSelector: {{ .Values.gateway.gatewayParameters.nodeSelector | toYaml | nindent 12 }}
+          {{- end }}
   {{- end }}
   service: |
     {{- if eq $gatewayClassName "data-science-gateway-class" }}

--- a/charts/llm-d-infra/values.schema.json
+++ b/charts/llm-d-infra/values.schema.json
@@ -241,6 +241,15 @@
                             "required": [],
                             "title": "logLevel"
                         },
+                        "nodeSelector": {
+                            "additionalProperties": {
+                                "type": "string"
+                            },
+                            "description": "Optional node selector for the gateway pod",
+                            "required": [],
+                            "title": "nodeSelector",
+                            "type": "object"
+                        },
                         "resources": {
                             "description": "ResourceRequirements describes the compute resource requirements.",
                             "properties": {

--- a/charts/llm-d-infra/values.schema.tmpl.json
+++ b/charts/llm-d-infra/values.schema.tmpl.json
@@ -241,6 +241,15 @@
               "required": [],
               "title": "logLevel"
             },
+            "nodeSelector": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "Optional node selector for the gateway pod",
+              "required": [],
+              "title": "nodeSelector",
+              "type": "object"
+            },
             "resources": {
               "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master/_definitions.json#/definitions/io.k8s.api.core.v1.ResourceRequirements",
               "description": "Resource requests/limits \u003cbr /\u003e Ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-requests-and-limits-of-pod-and-container",

--- a/charts/llm-d-infra/values.yaml
+++ b/charts/llm-d-infra/values.yaml
@@ -113,6 +113,17 @@ gateway:
         memory: 128Mi
 
     # @schema
+    # type: object
+    # additionalProperties:
+    #   type: string
+    # description: >
+    #   Optional. Node selector for the gateway pod.
+    #   Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+    # @schema
+    # -- Optional node selector for the gateway pod
+    nodeSelector: {}
+
+    # @schema
     # additionalProperties: false
     # @schema
     # -- Istio-specific parameters rendered into the gateway ConfigMap when gateway.provider resolves to "istio"


### PR DESCRIPTION
- Introduce `gateway.gatewayParameters.nodeSelector` in `values.yaml` to
    allow configuring node affinity for the gateway pod.
- Update `AgentgatewayParameters` template to conditionally render `nodeSelector` parameter when specified (agentgateway provider only).
- Update istio `ConfigMap` template to conditionally render `nodeSelector` parameter when specified (istio provider).
    
This change is not applied when using the `kgateway` provider because it is a deprecated compatibility mode